### PR TITLE
Fix Palo Alto input parsing issue (#11)

### DIFF
--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoParser.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoParser.java
@@ -18,6 +18,7 @@ package org.graylog.integrations.inputs.paloalto;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
@@ -62,6 +63,8 @@ public class PaloAltoParser {
          *  Note the ' - - - - ' delimiter for panorama.
          */
 
+        // Trim off line breaks from the end of the message payload.
+        raw = StringUtils.trim(raw);
         if (PANORAMA_SYSLOG_PARSER.matcher(raw).matches()) {
             LOG.trace("Message is in Panorama format [{}]", raw);
             final Matcher matcher = PANORAMA_SYSLOG_PARSER.matcher(raw);

--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTCPInput.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTCPInput.java
@@ -18,7 +18,7 @@ package org.graylog.integrations.inputs.paloalto;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.assistedinject.Assisted;
-import org.graylog2.inputs.transports.TcpTransport;
+import org.graylog2.inputs.transports.SyslogTcpTransport;
 import org.graylog2.plugin.LocalMetricRegistry;
 import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.buffers.InputBuffer;
@@ -45,7 +45,7 @@ public class PaloAltoTCPInput extends MessageInput {
     @Inject
     public PaloAltoTCPInput(@Assisted Configuration configuration,
                             MetricRegistry metricRegistry,
-                            TcpTransport.Factory transport,
+                            SyslogTcpTransport.Factory transport,
                             LocalMetricRegistry localRegistry,
                             PaloAltoCodec.Factory codec,
                             Config config,
@@ -99,7 +99,7 @@ public class PaloAltoTCPInput extends MessageInput {
     public static class Config extends MessageInput.Config {
 
         @Inject
-        public Config(TcpTransport.Factory transport, PaloAltoCodec.Factory codec) {
+        public Config(SyslogTcpTransport.Factory transport, PaloAltoCodec.Factory codec) {
             super(transport.getConfig(), codec.getConfig());
         }
     }


### PR DESCRIPTION
* Use Syslog TCP transport to correctly handle frame length
* Fully migrate to Syslog TCP Transport
* Trim line breaks from the message before parsing
* Add tests
* Roll back log message

Fixes #10

(cherry picked from commit d99cdc2f32ec4dc27c63e240d7ef5929b6dbd0e3)