### PR TITLE
Update Integrations repo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,10 @@
 # Integrations Plugin for Graylog
 
-**Required Graylog version:** 2.5 and later
-
-Content
--------
-
-This plugin includes the following features:
- * [Palo Alto input](http://docs.graylog.org/en/2.5/pages/integrations.html#palo-alto-networks-input-tcp)
-
-Installation
-------------
-
-See the [Releases](https://github.com/Graylog2/graylog-plugin-integrations/releases) page to access the latest versions 
-of the plugin. A typical plugin JAR and Debian/RPM packages are available for download. Public URLs are also included 
-for each for remote installs. Please make sure to not publicly distribute the download links. 
-
-The installation process is the same as any other plugin: Place the `.jar` file in your Graylog plugin directory. 
-See the [docs](http://docs.graylog.org/en/2.5/pages/plugins.html#installing-and-loading-plugins) for more info.  
-
-Releases
+Overview
 --------
 
-This plugin will be released approximately once per quarter (and timed with `graylog-server` when possible). Each build of the 
-plugin will target a specific (and usually current) `graylog-server` version. 
+Integrations are tools that help Graylog work with external systems. This plugin contains all open source integrations
+features.
+
+Please refer to the [documentation](http://docs.graylog.org/en/3.0/pages/integrations.html) for additional details 
+and setup instructions.     


### PR DESCRIPTION
This PR removes duplicate and outdated details from the Integrations repo readme. Most of the details are present in the official docs http://docs.graylog.org/en/3.0/pages/integrations.html, so I thought it made sense to just refer the user to them and not duplicate the details here in this readme.