### PR TITLE
Kinesis-related code cleanup

### DIFF
--- a/src/main/java/org/graylog/integrations/aws/KinesisService.java
+++ b/src/main/java/org/graylog/integrations/aws/KinesisService.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ExecutionException;
 public class KinesisService {
 
     private static final Logger LOG = LoggerFactory.getLogger(AWSService.class);
-    private static final int KINESIS_LIST_STREAMS_MAX_ATTEMPTS = 100;
+    private static final int KINESIS_LIST_STREAMS_MAX_ATTEMPTS = 1000;
     private static final int KINESIS_LIST_STREAMS_LIMIT = 30;
 
     private final KinesisClientBuilder kinesisClientBuilder;
@@ -37,11 +37,6 @@ public class KinesisService {
     public KinesisService(KinesisClientBuilder kinesisClientBuilder) {
 
         this.kinesisClientBuilder = kinesisClientBuilder;
-    }
-
-    static KinesisClient getKinesisClient() {
-        KinesisClient kinesisClient = KinesisClient.create();
-        return kinesisClient;
     }
 
     public KinesisHealthCheckResponse healthCheck(KinesisHealthCheckRequest heathCheckRequest) {
@@ -124,5 +119,4 @@ public class KinesisService {
     // TODO Subscribe to Kinesis Stream
 
     // TODO getRecord
-
 }

--- a/src/main/java/org/graylog/integrations/aws/resources/responses/KinesisHealthCheckResponse.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/responses/KinesisHealthCheckResponse.java
@@ -23,7 +23,7 @@ public abstract class KinesisHealthCheckResponse {
     public abstract String message();
 
     public static KinesisHealthCheckResponse create(@JsonProperty("success") boolean success,
-                                                    @JsonProperty("logType") String logType,
+                                                    @JsonProperty("log_type") String logType,
                                                     @JsonProperty("message") String message) {
         return new AutoValue_KinesisHealthCheckResponse(success, logType, message);
     }

--- a/src/main/java/org/graylog/integrations/aws/resources/responses/RegionResponse.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/responses/RegionResponse.java
@@ -23,9 +23,9 @@ public abstract class RegionResponse {
     @JsonProperty
     public abstract String displayValue();
 
-    public static RegionResponse create(@JsonProperty("regionId") String regionId,
-                                        @JsonProperty("regionDescription") String regionDescription,
-                                        @JsonProperty("displayValue") String displayValue ) {
+    public static RegionResponse create(@JsonProperty("region_id") String regionId,
+                                        @JsonProperty("region_description") String regionDescription,
+                                        @JsonProperty("display_value") String displayValue ) {
         return new AutoValue_RegionResponse(regionId, regionDescription, displayValue);
     }
 }


### PR DESCRIPTION
Kinesis cleanup:
 - Remove unneeded method
 - Increase max # of Kinesis pages that can be pulled from 100 to 1000. This is a max limit to prevent potential infinite loop.
 - Use underscore_case instead of cammelCase for JSON properties. Generally in Graylog we use underscores.