### PR TITLE
Add Available Services API call

### DIFF
--- a/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
@@ -8,6 +8,7 @@ import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog.integrations.aws.KinesisService;
 import org.graylog.integrations.aws.cloudwatch.CloudWatchService;
 import org.graylog.integrations.aws.resources.requests.KinesisHealthCheckRequest;
+import org.graylog.integrations.aws.resources.responses.AvailableAWSServiceSummmary;
 import org.graylog.integrations.aws.resources.responses.KinesisHealthCheckResponse;
 import org.graylog.integrations.aws.resources.responses.RegionResponse;
 import org.graylog.integrations.aws.service.AWSService;
@@ -57,6 +58,23 @@ public class AWSResource implements PluginRestResource {
     @ApiOperation(value = "Get all available AWS regions")
     public List<RegionResponse> getAwsRegions() {
         return awsService.getAvailableRegions();
+    }
+
+    /**
+     * Performs an AWS HealthCheck
+     *
+     * Sample CURL command for executing this method. Use this to model the UI request.
+     * Note the --data-binary param that includes the put body JSON with region and AWS credentials.
+     *
+     * curl http://someuser:somepass@localhost:9000/api/plugins/org.graylog.integrations/aws/availableServices
+     */
+    @GET
+    @Timed
+    @Path("/availableServices")
+    @ApiOperation(value = "Get all available AWS services")
+    public AvailableAWSServiceSummmary getAvailableServices() {
+
+        return awsService.getAvailableServices();
     }
 
     // GET CloudWatch log group names

--- a/src/main/java/org/graylog/integrations/aws/resources/responses/AvailableAWSService.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/responses/AvailableAWSService.java
@@ -1,0 +1,41 @@
+package org.graylog.integrations.aws.resources.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class AvailableAWSService {
+
+    private static final String NAME = "name";
+    private static final String DESCRIPTION = "description";
+    private static final String POLICY = "policy";
+    private static final String HELPER_TEXT = "helper_text";
+    private static final String LEARN_MORE_LINK = "learn_more_link";
+
+    @JsonProperty(NAME)
+    public abstract String name();
+
+    @JsonProperty(DESCRIPTION)
+    public abstract String description();
+
+    @JsonProperty(POLICY)
+    public abstract String policy();
+
+    @JsonProperty(HELPER_TEXT)
+    public abstract String helperText();
+
+    @JsonProperty(LEARN_MORE_LINK)
+    public abstract String LearnMoreLink();
+
+    public static AvailableAWSService create(@JsonProperty(NAME) String name,
+                                             @JsonProperty(DESCRIPTION) String description,
+                                             @JsonProperty(POLICY) String policy,
+                                             @JsonProperty(HELPER_TEXT) String helperText,
+                                             @JsonProperty(LEARN_MORE_LINK) String LearnMoreLink) {
+        return new AutoValue_AvailableAWSService(name, description, policy, helperText, LearnMoreLink);
+    }
+}

--- a/src/main/java/org/graylog/integrations/aws/resources/responses/AvailableAWSServiceSummmary.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/responses/AvailableAWSServiceSummmary.java
@@ -1,0 +1,28 @@
+package org.graylog.integrations.aws.resources.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+import java.util.List;
+
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class AvailableAWSServiceSummmary {
+
+    private static final String SERVICES = "services";
+    private static final String TOTAL = "total";
+
+    @JsonProperty(SERVICES)
+    public abstract List<AvailableAWSService> services();
+
+    @JsonProperty(TOTAL)
+    public abstract long total();
+
+    public static AvailableAWSServiceSummmary create(@JsonProperty(SERVICES) List<AvailableAWSService> services,
+                                                     @JsonProperty(TOTAL) long total) {
+        return new AutoValue_AvailableAWSServiceSummmary(services, total);
+    }
+}

--- a/src/main/java/org/graylog/integrations/aws/service/AWSService.java
+++ b/src/main/java/org/graylog/integrations/aws/service/AWSService.java
@@ -2,14 +2,22 @@ package org.graylog.integrations.aws.service;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang.StringUtils;
+import com.google.common.base.Preconditions;
+import org.graylog.integrations.aws.resources.responses.AvailableAWSService;
+import org.graylog.integrations.aws.resources.responses.AvailableAWSServiceSummmary;
+import org.apache.commons.lang.StringUtils;
 import org.graylog.integrations.aws.resources.responses.RegionResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.RegionMetadata;
 
+import java.util.ArrayList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -47,5 +55,52 @@ public class AWSService {
         Preconditions.checkArgument(StringUtils.isNotBlank(secretAccessKey), "An AWS secret key is required.");
 
         return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKeyId, secretAccessKey));
+    }
+
+    /**
+     * @return A list of available AWS services supported by the AWS Graylog AWS integration.
+     */
+    public AvailableAWSServiceSummmary getAvailableServices() {
+
+        ArrayList<AvailableAWSService> services = new ArrayList<>();
+        AvailableAWSService cloudWatchService =
+                AvailableAWSService.create("CloudWatch",
+                                           "Retrieve CloudWatch logs via Kinesis. Kinesis allows streaming of the logs" +
+                                           "in real time. Amazon CloudWatch is a monitoring and management service built" +
+                                           "for developers, system operators, site reliability engineers (SRE), " +
+                                           "and IT managers.",
+                                           "{\n" +
+                                           "  \"Version\": \"2012-10-17\",\n" +
+                                           "  \"Statement\": [\n" +
+                                           "    {\n" +
+                                           "      \"Sid\": \"VisualEditor0\",\n" +
+                                           "      \"Effect\": \"Allow\",\n" +
+                                           "      \"Action\": [\n" +
+                                           "        \"cloudwatch:PutMetricData\",\n" +
+                                           "        \"dynamodb:CreateTable\",\n" +
+                                           "        \"dynamodb:DescribeTable\",\n" +
+                                           "        \"dynamodb:GetItem\",\n" +
+                                           "        \"dynamodb:PutItem\",\n" +
+                                           "        \"dynamodb:Scan\",\n" +
+                                           "        \"dynamodb:UpdateItem\",\n" +
+                                           "        \"ec2:DescribeInstances\",\n" +
+                                           "        \"ec2:DescribeNetworkInterfaceAttribute\",\n" +
+                                           "        \"ec2:DescribeNetworkInterfaces\",\n" +
+                                           "        \"elasticloadbalancing:DescribeLoadBalancerAttributes\",\n" +
+                                           "        \"elasticloadbalancing:DescribeLoadBalancers\",\n" +
+                                           "        \"kinesis:GetRecords\",\n" +
+                                           "        \"kinesis:GetShardIterator\",\n" +
+                                           "        \"kinesis:ListShards\"\n" +
+                                           "      ],\n" +
+                                           "      \"Resource\": \"*\"\n" +
+                                           "    }\n" +
+                                           "  ]\n" +
+                                           "}",
+                                           "Requires Kinesis",
+                                           "https://aws.amazon.com/cloudwatch/"
+                );
+        services.add(cloudWatchService);
+
+        return AvailableAWSServiceSummmary.create(services, services.size());
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/service/AWSService.java
+++ b/src/main/java/org/graylog/integrations/aws/service/AWSService.java
@@ -65,8 +65,8 @@ public class AWSService {
         ArrayList<AvailableAWSService> services = new ArrayList<>();
         AvailableAWSService cloudWatchService =
                 AvailableAWSService.create("CloudWatch",
-                                           "Retrieve CloudWatch logs via Kinesis. Kinesis allows streaming of the logs" +
-                                           "in real time. Amazon CloudWatch is a monitoring and management service built" +
+                                           "Retrieve CloudWatch logs via Kinesis. Kinesis allows streaming of the logs " +
+                                           "in real time. AWS CloudWatch is a monitoring and management service built " +
                                            "for developers, system operators, site reliability engineers (SRE), " +
                                            "and IT managers.",
                                            "{\n" +

--- a/src/test/java/org.graylog.integrations/aws/AWSServiceTest.java
+++ b/src/test/java/org.graylog.integrations/aws/AWSServiceTest.java
@@ -1,5 +1,6 @@
 package org.graylog.integrations.aws;
 
+import org.graylog.integrations.aws.resources.responses.AvailableAWSServiceSummmary;
 import org.graylog.integrations.aws.resources.responses.RegionResponse;
 import org.graylog.integrations.aws.service.AWSService;
 import org.junit.Before;
@@ -40,5 +41,18 @@ public class AWSServiceTest {
         assertTrue(availableRegions.stream().anyMatch(r -> r.displayValue().equals("EU (Stockholm): eu-north-1")));
         assertEquals("There should be 20 total regions. This will change in future versions of the AWS SDK",
                      20, availableRegions.size());
+    }
+
+    @Test
+    public void testAvailableServices() {
+
+        AvailableAWSServiceSummmary services = awsService.getAvailableServices();
+
+        // There should be one service.
+        assertEquals(1, services.total());
+        assertEquals(1, services.services().size());
+
+        // CloudWatch should be in the list of available services.
+        assertTrue(services.services().stream().anyMatch(s -> s.name().equals("CloudWatch")));
     }
 }


### PR DESCRIPTION
Add API call that returns a list of available services for the Choose from Available Services page. 

To test this out, this CURL command can be used: `curl http://someuser:somepass@localhost:9000/api/plugins/org.graylog.integrations/aws/availableServices`

Resolves #50 