### PR TITLE
Pass region and AWS credentials with AWS API requests

### DIFF
--- a/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
@@ -28,7 +28,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -57,7 +56,7 @@ public class AWSResource implements PluginRestResource {
     @Timed
     @Path("/regions")
     @ApiOperation(value = "Get all available AWS regions")
-    public List<RegionsResponse> getAwsRegions() {
+    public RegionsResponse getAwsRegions() {
         return awsService.getAvailableRegions();
     }
 

--- a/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
@@ -63,7 +63,7 @@ public class AWSResource implements PluginRestResource {
 
     @GET
     @Timed
-    @Path("/availableServices")
+    @Path("/available_services")
     @ApiOperation(value = "Get all available AWS services")
     public AvailableServiceResponse getAvailableServices() {
         return awsService.getAvailableServices();
@@ -86,8 +86,8 @@ public class AWSResource implements PluginRestResource {
      */
     @POST
     @Timed
-    @Path("/cloudWatch/logGroups")
-    @ApiOperation(value = "Get all available AWS CloudWatch log groups names for the specified region")
+    @Path("/cloudwatch/log_groups")
+    @ApiOperation(value = "Get all available AWS CloudWatch log groups names for the specified region.")
     public LogGroupsResponse getLogGroupNames(@ApiParam(name = "JSON body", required = true) @Valid @NotNull AWSRequestImpl awsRequest) {
         return cloudWatchService.getLogGroupNames(awsRequest.region(), awsRequest.awsAccessKeyId(), awsRequest.awsSecretAccessKey());
     }
@@ -110,7 +110,7 @@ public class AWSResource implements PluginRestResource {
     @POST
     @Timed
     @Path("/kinesis/streams")
-    @ApiOperation(value = "Get all available Kinesis streams for the specified region")
+    @ApiOperation(value = "Get all available Kinesis streams for the specified region.")
     public StreamsResponse getKinesisStreams(@ApiParam(name = "JSON body", required = true) @Valid @NotNull AWSRequestImpl awsRequest) throws ExecutionException {
         return kinesisService.getKinesisStreamNames(awsRequest.region(), awsRequest.awsAccessKeyId(), awsRequest.awsSecretAccessKey());
     }
@@ -136,7 +136,7 @@ public class AWSResource implements PluginRestResource {
      */
     @POST
     @Timed
-    @Path("/kinesis/healthCheck")
+    @Path("/kinesis/health_check")
     @ApiOperation(
             value = "Attempt to retrieve logs from the indicated AWS log group with the specified credentials.",
             response = HealthCheckResponse.class

--- a/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
@@ -5,13 +5,16 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
-import org.graylog.integrations.aws.service.KinesisService;
-import org.graylog.integrations.aws.service.CloudWatchService;
+import org.graylog.integrations.aws.resources.requests.AWSRequestImpl;
 import org.graylog.integrations.aws.resources.requests.KinesisHealthCheckRequest;
-import org.graylog.integrations.aws.resources.responses.AvailableAWSServiceSummmary;
-import org.graylog.integrations.aws.resources.responses.KinesisHealthCheckResponse;
-import org.graylog.integrations.aws.resources.responses.RegionResponse;
+import org.graylog.integrations.aws.resources.responses.AvailableServiceResponse;
+import org.graylog.integrations.aws.resources.responses.HealthCheckResponse;
+import org.graylog.integrations.aws.resources.responses.LogGroupsResponse;
+import org.graylog.integrations.aws.resources.responses.RegionsResponse;
+import org.graylog.integrations.aws.resources.responses.StreamsResponse;
 import org.graylog.integrations.aws.service.AWSService;
+import org.graylog.integrations.aws.service.CloudWatchService;
+import org.graylog.integrations.aws.service.KinesisService;
 import org.graylog2.plugin.rest.PluginRestResource;
 
 import javax.inject.Inject;
@@ -19,9 +22,8 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
-import javax.ws.rs.PUT;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -55,7 +57,7 @@ public class AWSResource implements PluginRestResource {
     @Timed
     @Path("/regions")
     @ApiOperation(value = "Get all available AWS regions")
-    public List<RegionResponse> getAwsRegions() {
+    public List<RegionsResponse> getAwsRegions() {
         return awsService.getAvailableRegions();
     }
 
@@ -63,28 +65,54 @@ public class AWSResource implements PluginRestResource {
     @Timed
     @Path("/availableServices")
     @ApiOperation(value = "Get all available AWS services")
-    public AvailableAWSServiceSummmary getAvailableServices() {
+    public AvailableServiceResponse getAvailableServices() {
         return awsService.getAvailableServices();
     }
 
-    // TODO: Rework to accept a form post body with credentials
-    @GET
+    /**
+     * Get all available AWS CloudWatch log groups names for the specified region.
+     *
+     * Example request:
+     * curl 'http://user:pass@localhost:9000/api/plugins/org.graylog.integrations/aws/cloudWatch/logGroups' \
+     * -X POST \
+     * -H 'X-Requested-By: XMLHttpRequest' \
+     * -H 'Content-Type: application/json'   \
+     * -H 'Accept: application/json' \
+     * --data-binary '{
+     * "region": "us-east-1",
+     * "aws_access_key_id": "some-key",
+     * "aws_secret_access_key": "some-secret"
+     * }'
+     */
+    @POST
     @Timed
-    @Path("/cloudWatch/logGroups/{regionName}")
+    @Path("/cloudWatch/logGroups")
     @ApiOperation(value = "Get all available AWS CloudWatch log groups names for the specified region")
-    public List<String> getLogGroupNames(@ApiParam(name = "regionName", required = true)
-                                         @PathParam("regionName") String regionName) {
-        return cloudWatchService.getLogGroupNames(regionName);
+    public LogGroupsResponse getLogGroupNames(@ApiParam(name = "JSON body", required = true) @Valid @NotNull AWSRequestImpl awsRequest) {
+        return cloudWatchService.getLogGroupNames(awsRequest.region(), awsRequest.awsAccessKeyId(), awsRequest.awsSecretAccessKey());
     }
 
-    // TODO: Rework to accept a form post body with credentials
-    @GET
+    /**
+     * Get all available Kinesis streams for the specified region.
+     *
+     * Example request:
+     * curl 'http://user:pass@localhost:9000/api/plugins/org.graylog.integrations/aws/kinesis/streams' \
+     * -X POST \
+     * -H 'X-Requested-By: XMLHttpRequest' \
+     * -H 'Content-Type: application/json'   \
+     * -H 'Accept: application/json' \
+     * --data-binary '{
+     * "region": "us-east-1",
+     * "aws_access_key_id": "some-key",
+     * "aws_secret_access_key": "some-secret"
+     * }'
+     */
+    @POST
     @Timed
-    @Path("/kinesis/streams/{regionName}")
-    @ApiOperation(value = "Get all available AWS Kinesis streams for the specified region")
-    public List<String> getKinesisStreams(@ApiParam(name = "regionName", required = true)
-                                          @PathParam("regionName") String regionName) throws ExecutionException {
-        return kinesisService.getKinesisStreams(regionName, null, null);
+    @Path("/kinesis/streams")
+    @ApiOperation(value = "Get all available Kinesis streams for the specified region")
+    public StreamsResponse getKinesisStreams(@ApiParam(name = "JSON body", required = true) @Valid @NotNull AWSRequestImpl awsRequest) throws ExecutionException {
+        return kinesisService.getKinesisStreamNames(awsRequest.region(), awsRequest.awsAccessKeyId(), awsRequest.awsSecretAccessKey());
     }
 
     /**
@@ -93,29 +121,28 @@ public class AWSResource implements PluginRestResource {
      * Sample CURL command for executing this method. Use this to model the UI request.
      * Note the --data-binary param that includes the put body JSON with region and AWS credentials.
      *
-     * curl 'http://someuser:somepass@localhost:9000/api/plugins/org.graylog.integrations/aws/kinesis/healthCheck' \
-     * -X PUT \
+     * curl 'http://user:pass@localhost:9000/api/plugins/org.graylog.integrations/aws/kinesis/healthCheck' \
+     * -X POST \
      * -H 'X-Requested-By: XMLHttpRequest' \
      * -H 'Content-Type: application/json'   \
      * -H 'Accept: application/json' \
      * --data-binary '{
-     *   "region": "us-east-1",
-     *   "aws_access_key_id": "some-key",
-     *   "aws_secret_access_key": "some-secret",
-     *   "stream_name": "a-stream",
-     *   "log_group_name": "a-log-group"
+     * "region": "us-east-1",
+     * "aws_access_key_id": "some-key",
+     * "aws_secret_access_key": "some-secret",
+     * "stream_name": "a-stream",
+     * "log_group_name": "a-log-group"
      * }'
-     *
      */
-    @PUT
+    @POST
     @Timed
     @Path("/kinesis/healthCheck")
     @ApiOperation(
             value = "Attempt to retrieve logs from the indicated AWS log group with the specified credentials.",
-            response = KinesisHealthCheckResponse.class
+            response = HealthCheckResponse.class
     )
     public Response kinesisHealthCheck(@ApiParam(name = "JSON body", required = true) @Valid @NotNull KinesisHealthCheckRequest heathCheckRequest) throws ExecutionException, IOException {
-        KinesisHealthCheckResponse response = kinesisService.healthCheck(heathCheckRequest);
+        HealthCheckResponse response = kinesisService.healthCheck(heathCheckRequest);
         return Response.accepted().entity(response).build();
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/resources/requests/AWSRequestImpl.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/requests/AWSRequestImpl.java
@@ -1,0 +1,32 @@
+package org.graylog.integrations.aws.resources.requests;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+/**
+ * A common implementation on AWSRequest, which can be used for any AWS request that just needs region and credentials.
+ */
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class AWSRequestImpl implements AWSRequest {
+
+    @JsonProperty(REGION)
+    public abstract String region();
+
+    @JsonProperty(AWS_ACCESS_KEY_ID)
+    public abstract String awsAccessKeyId();
+
+    @JsonProperty(AWS_SECRET_ACCESS_KEY)
+    public abstract String awsSecretAccessKey();
+
+    @JsonCreator
+    public static AWSRequestImpl create(@JsonProperty(REGION) String region,
+                                        @JsonProperty(AWS_ACCESS_KEY_ID) String awsAccessKeyId,
+                                        @JsonProperty(AWS_SECRET_ACCESS_KEY) String awsSecretAccessKey) {
+        return new AutoValue_AWSRequestImpl(region, awsAccessKeyId, awsSecretAccessKey);
+    }
+}

--- a/src/main/java/org/graylog/integrations/aws/resources/responses/AWSRegion.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/responses/AWSRegion.java
@@ -1,0 +1,29 @@
+package org.graylog.integrations.aws.resources.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class AWSRegion {
+
+    private static final String VALUE = "value";
+    private static final String LABEL = "label";
+
+    // eu-west-2
+    @JsonProperty(VALUE)
+    public abstract String regionId();
+
+    // The combination of both the name and description for display in the UI:
+    // EU (London): eu-west-2
+    @JsonProperty(LABEL)
+    public abstract String displayValue();
+
+    public static AWSRegion create(@JsonProperty(VALUE) String value,
+                                   @JsonProperty(LABEL) String label) {
+        return new AutoValue_AWSRegion(value, label);
+    }
+}

--- a/src/main/java/org/graylog/integrations/aws/resources/responses/AvailableService.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/responses/AvailableService.java
@@ -8,7 +8,7 @@ import org.graylog.autovalue.WithBeanGetter;
 @JsonAutoDetect
 @AutoValue
 @WithBeanGetter
-public abstract class AvailableAWSService {
+public abstract class AvailableService {
 
     private static final String NAME = "name";
     private static final String DESCRIPTION = "description";
@@ -31,11 +31,11 @@ public abstract class AvailableAWSService {
     @JsonProperty(LEARN_MORE_LINK)
     public abstract String LearnMoreLink();
 
-    public static AvailableAWSService create(@JsonProperty(NAME) String name,
-                                             @JsonProperty(DESCRIPTION) String description,
-                                             @JsonProperty(POLICY) String policy,
-                                             @JsonProperty(HELPER_TEXT) String helperText,
-                                             @JsonProperty(LEARN_MORE_LINK) String LearnMoreLink) {
-        return new AutoValue_AvailableAWSService(name, description, policy, helperText, LearnMoreLink);
+    public static AvailableService create(@JsonProperty(NAME) String name,
+                                          @JsonProperty(DESCRIPTION) String description,
+                                          @JsonProperty(POLICY) String policy,
+                                          @JsonProperty(HELPER_TEXT) String helperText,
+                                          @JsonProperty(LEARN_MORE_LINK) String LearnMoreLink) {
+        return new AutoValue_AvailableService(name, description, policy, helperText, LearnMoreLink);
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/resources/responses/AvailableServiceResponse.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/responses/AvailableServiceResponse.java
@@ -10,19 +10,19 @@ import java.util.List;
 @JsonAutoDetect
 @AutoValue
 @WithBeanGetter
-public abstract class AvailableAWSServiceSummmary {
+public abstract class AvailableServiceResponse {
 
     private static final String SERVICES = "services";
     private static final String TOTAL = "total";
 
     @JsonProperty(SERVICES)
-    public abstract List<AvailableAWSService> services();
+    public abstract List<AvailableService> services();
 
     @JsonProperty(TOTAL)
     public abstract long total();
 
-    public static AvailableAWSServiceSummmary create(@JsonProperty(SERVICES) List<AvailableAWSService> services,
-                                                     @JsonProperty(TOTAL) long total) {
-        return new AutoValue_AvailableAWSServiceSummmary(services, total);
+    public static AvailableServiceResponse create(@JsonProperty(SERVICES) List<AvailableService> services,
+                                                  @JsonProperty(TOTAL) long total) {
+        return new AutoValue_AvailableServiceResponse(services, total);
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/resources/responses/HealthCheckResponse.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/responses/HealthCheckResponse.java
@@ -11,7 +11,7 @@ import javax.annotation.Nullable;
 @JsonAutoDetect
 @AutoValue
 @WithBeanGetter
-public abstract class KinesisHealthCheckResponse {
+public abstract class HealthCheckResponse {
 
     private static final String SUCCESS = "success";
     private static final String LOG_TYPE = "log_type";
@@ -36,10 +36,10 @@ public abstract class KinesisHealthCheckResponse {
     @JsonProperty(MESSAGE_SUMMARY)
     public abstract String messageSummary();
 
-    public static KinesisHealthCheckResponse create(@JsonProperty(SUCCESS) boolean success,
-                                                    @JsonProperty(LOG_TYPE) String logType,
-                                                    @JsonProperty(EXPLANATION) String explanation,
-                                                    @JsonProperty(MESSAGE_SUMMARY) String messageSummary) {
-        return new AutoValue_KinesisHealthCheckResponse(success, logType, explanation, messageSummary);
+    public static HealthCheckResponse create(@JsonProperty(SUCCESS) boolean success,
+                                             @JsonProperty(LOG_TYPE) String logType,
+                                             @JsonProperty(EXPLANATION) String explanation,
+                                             @JsonProperty(MESSAGE_SUMMARY) String messageSummary) {
+        return new AutoValue_HealthCheckResponse(success, logType, explanation, messageSummary);
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/resources/responses/LogGroupsResponse.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/responses/LogGroupsResponse.java
@@ -1,0 +1,28 @@
+package org.graylog.integrations.aws.resources.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+import java.util.List;
+
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class LogGroupsResponse {
+
+    private static final String LOG_GROUPS = "log_groups";
+    private static final String TOTAL = "total";
+
+    @JsonProperty(LOG_GROUPS)
+    public abstract List<String> logGroups();
+
+    @JsonProperty(TOTAL)
+    public abstract long total();
+
+    public static LogGroupsResponse create(@JsonProperty(LOG_GROUPS) List<String> logGroups,
+                                           @JsonProperty(TOTAL) long total) {
+        return new AutoValue_LogGroupsResponse(logGroups, total);
+    }
+}

--- a/src/main/java/org/graylog/integrations/aws/resources/responses/RegionsResponse.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/responses/RegionsResponse.java
@@ -8,7 +8,7 @@ import org.graylog.autovalue.WithBeanGetter;
 @JsonAutoDetect
 @AutoValue
 @WithBeanGetter
-public abstract class RegionResponse {
+public abstract class RegionsResponse {
 
     private static final String REGION_ID = "region_id";
     private static final String REGION_DESCRIPTION = "region_description";
@@ -27,9 +27,9 @@ public abstract class RegionResponse {
     @JsonProperty(DISPLAY_VALUE)
     public abstract String displayValue();
 
-    public static RegionResponse create(@JsonProperty(REGION_ID) String regionId,
-                                        @JsonProperty(REGION_DESCRIPTION) String regionDescription,
-                                        @JsonProperty(DISPLAY_VALUE) String displayValue) {
-        return new AutoValue_RegionResponse(regionId, regionDescription, displayValue);
+    public static RegionsResponse create(@JsonProperty(REGION_ID) String regionId,
+                                         @JsonProperty(REGION_DESCRIPTION) String regionDescription,
+                                         @JsonProperty(DISPLAY_VALUE) String displayValue) {
+        return new AutoValue_RegionsResponse(regionId, regionDescription, displayValue);
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/resources/responses/RegionsResponse.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/responses/RegionsResponse.java
@@ -5,31 +5,24 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 
+import java.util.List;
+
 @JsonAutoDetect
 @AutoValue
 @WithBeanGetter
 public abstract class RegionsResponse {
 
-    private static final String REGION_ID = "region_id";
-    private static final String REGION_DESCRIPTION = "region_description";
-    private static final String DISPLAY_VALUE = "display_value";
+    private static final String REGIONS = "regions";
+    private static final String TOTAL = "total";
 
-    // eu-west-2
-    @JsonProperty(REGION_ID)
-    public abstract String regionId();
+    @JsonProperty(REGIONS)
+    public abstract List<AWSRegion> regions();
 
-    // EU (London)
-    @JsonProperty(REGION_DESCRIPTION)
-    public abstract String regionDescription();
+    @JsonProperty(TOTAL)
+    public abstract long total();
 
-    // The combination of both the name and description for display in the UI:
-    // EU (London): eu-west-2
-    @JsonProperty(DISPLAY_VALUE)
-    public abstract String displayValue();
-
-    public static RegionsResponse create(@JsonProperty(REGION_ID) String regionId,
-                                         @JsonProperty(REGION_DESCRIPTION) String regionDescription,
-                                         @JsonProperty(DISPLAY_VALUE) String displayValue) {
-        return new AutoValue_RegionsResponse(regionId, regionDescription, displayValue);
+    public static RegionsResponse create(@JsonProperty(REGIONS) List<AWSRegion> regions,
+                                         @JsonProperty(TOTAL) long total) {
+        return new AutoValue_RegionsResponse(regions, total);
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/resources/responses/StreamsResponse.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/responses/StreamsResponse.java
@@ -1,0 +1,28 @@
+package org.graylog.integrations.aws.resources.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+import java.util.List;
+
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class StreamsResponse {
+
+    private static final String STREAMS = "streams";
+    private static final String TOTAL = "total";
+
+    @JsonProperty(STREAMS)
+    public abstract List<String> streams();
+
+    @JsonProperty(TOTAL)
+    public abstract long total();
+
+    public static StreamsResponse create(@JsonProperty(STREAMS) List<String> streams,
+                                         @JsonProperty(TOTAL) long total) {
+        return new AutoValue_StreamsResponse(streams, total);
+    }
+}

--- a/src/main/java/org/graylog/integrations/aws/service/AWSService.java
+++ b/src/main/java/org/graylog/integrations/aws/service/AWSService.java
@@ -2,6 +2,7 @@ package org.graylog.integrations.aws.service;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang.StringUtils;
+import org.graylog.integrations.aws.resources.responses.AWSRegion;
 import org.graylog.integrations.aws.resources.responses.AvailableService;
 import org.graylog.integrations.aws.resources.responses.AvailableServiceResponse;
 import org.graylog.integrations.aws.resources.responses.RegionsResponse;
@@ -13,6 +14,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.RegionMetadata;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -26,17 +28,22 @@ public class AWSService {
     /**
      * @return A list of all available regions.
      */
-    public List<RegionsResponse> getAvailableRegions() {
+    public RegionsResponse getAvailableRegions() {
 
-        return Region.regions().stream()
-                     // Ignore the global region. CloudWatch and Kinesis cannot be used with global regions.
-                     .filter(r -> !r.isGlobalRegion())
-                     .map(r -> {
-                         // Build a single AWSRegionResponse with id, description, and displayValue.
-                         RegionMetadata regionMetadata = r.metadata();
-                         String displayValue = String.format("%s: %s", regionMetadata.description(), regionMetadata.id());
-                         return RegionsResponse.create(regionMetadata.id(), regionMetadata.description(), displayValue);
-                     }).collect(Collectors.toList());
+        List<AWSRegion> regions =
+                Region.regions().stream()
+                      // Ignore the global region. CloudWatch and Kinesis cannot be used with global regions.
+                      .filter(r -> !r.isGlobalRegion())
+                      .map(r -> {
+                          // Build a single AWSRegionResponse with id, description, and displayValue.
+                          RegionMetadata regionMetadata = r.metadata();
+                          String label = String.format("%s: %s", regionMetadata.description(), regionMetadata.id());
+                          return AWSRegion.create(regionMetadata.id(), label);
+                      })
+                      .sorted(Comparator.comparing(AWSRegion::regionId))
+                      .collect(Collectors.toList());
+
+        return RegionsResponse.create(regions, regions.size());
     }
 
     /**
@@ -59,37 +66,37 @@ public class AWSService {
         ArrayList<AvailableService> services = new ArrayList<>();
         AvailableService cloudWatchService =
                 AvailableService.create("CloudWatch",
-                                           "Retrieve CloudWatch logs via Kinesis. Kinesis allows streaming of the logs " +
-                                                   "in real time. AWS CloudWatch is a monitoring and management service built " +
-                                                   "for developers, system operators, site reliability engineers (SRE), " +
-                                                   "and IT managers.",
+                                        "Retrieve CloudWatch logs via Kinesis. Kinesis allows streaming of the logs " +
+                                        "in real time. AWS CloudWatch is a monitoring and management service built " +
+                                        "for developers, system operators, site reliability engineers (SRE), " +
+                                        "and IT managers.",
                                         "{\n" +
-                                                   "  \"Version\": \"2019-06-19\",\n" +
-                                                   "  \"Statement\": [\n" +
-                                                   "    {\n" +
-                                                   "      \"Sid\": \"GraylogCloudWatchPolicy\",\n" +
-                                                   "      \"Effect\": \"Allow\",\n" +
-                                                   "      \"Action\": [\n" +
-                                                   "        \"cloudwatch:PutMetricData\",\n" +
-                                                   "        \"dynamodb:CreateTable\",\n" +
-                                                   "        \"dynamodb:DescribeTable\",\n" +
-                                                   "        \"dynamodb:GetItem\",\n" +
-                                                   "        \"dynamodb:PutItem\",\n" +
-                                                   "        \"dynamodb:Scan\",\n" +
-                                                   "        \"dynamodb:UpdateItem\",\n" +
-                                                   "        \"ec2:DescribeInstances\",\n" +
-                                                   "        \"ec2:DescribeNetworkInterfaceAttribute\",\n" +
-                                                   "        \"ec2:DescribeNetworkInterfaces\",\n" +
-                                                   "        \"elasticloadbalancing:DescribeLoadBalancerAttributes\",\n" +
-                                                   "        \"elasticloadbalancing:DescribeLoadBalancers\",\n" +
-                                                   "        \"kinesis:GetRecords\",\n" +
-                                                   "        \"kinesis:GetShardIterator\",\n" +
-                                                   "        \"kinesis:ListShards\"\n" +
-                                                   "      ],\n" +
-                                                   "      \"Resource\": \"*\"\n" +
-                                                   "    }\n" +
-                                                   "  ]\n" +
-                                                   "}",
+                                        "  \"Version\": \"2019-06-19\",\n" +
+                                        "  \"Statement\": [\n" +
+                                        "    {\n" +
+                                        "      \"Sid\": \"GraylogCloudWatchPolicy\",\n" +
+                                        "      \"Effect\": \"Allow\",\n" +
+                                        "      \"Action\": [\n" +
+                                        "        \"cloudwatch:PutMetricData\",\n" +
+                                        "        \"dynamodb:CreateTable\",\n" +
+                                        "        \"dynamodb:DescribeTable\",\n" +
+                                        "        \"dynamodb:GetItem\",\n" +
+                                        "        \"dynamodb:PutItem\",\n" +
+                                        "        \"dynamodb:Scan\",\n" +
+                                        "        \"dynamodb:UpdateItem\",\n" +
+                                        "        \"ec2:DescribeInstances\",\n" +
+                                        "        \"ec2:DescribeNetworkInterfaceAttribute\",\n" +
+                                        "        \"ec2:DescribeNetworkInterfaces\",\n" +
+                                        "        \"elasticloadbalancing:DescribeLoadBalancerAttributes\",\n" +
+                                        "        \"elasticloadbalancing:DescribeLoadBalancers\",\n" +
+                                        "        \"kinesis:GetRecords\",\n" +
+                                        "        \"kinesis:GetShardIterator\",\n" +
+                                        "        \"kinesis:ListShards\"\n" +
+                                        "      ],\n" +
+                                        "      \"Resource\": \"*\"\n" +
+                                        "    }\n" +
+                                        "  ]\n" +
+                                        "}",
                                         "Requires Kinesis",
                                         "https://aws.amazon.com/cloudwatch/"
                 );

--- a/src/main/java/org/graylog/integrations/aws/service/AWSService.java
+++ b/src/main/java/org/graylog/integrations/aws/service/AWSService.java
@@ -2,9 +2,9 @@ package org.graylog.integrations.aws.service;
 
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang.StringUtils;
-import org.graylog.integrations.aws.resources.responses.AvailableAWSService;
-import org.graylog.integrations.aws.resources.responses.AvailableAWSServiceSummmary;
-import org.graylog.integrations.aws.resources.responses.RegionResponse;
+import org.graylog.integrations.aws.resources.responses.AvailableService;
+import org.graylog.integrations.aws.resources.responses.AvailableServiceResponse;
+import org.graylog.integrations.aws.resources.responses.RegionsResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -26,7 +26,7 @@ public class AWSService {
     /**
      * @return A list of all available regions.
      */
-    public List<RegionResponse> getAvailableRegions() {
+    public List<RegionsResponse> getAvailableRegions() {
 
         return Region.regions().stream()
                      // Ignore the global region. CloudWatch and Kinesis cannot be used with global regions.
@@ -35,7 +35,7 @@ public class AWSService {
                          // Build a single AWSRegionResponse with id, description, and displayValue.
                          RegionMetadata regionMetadata = r.metadata();
                          String displayValue = String.format("%s: %s", regionMetadata.description(), regionMetadata.id());
-                         return RegionResponse.create(regionMetadata.id(), regionMetadata.description(), displayValue);
+                         return RegionsResponse.create(regionMetadata.id(), regionMetadata.description(), displayValue);
                      }).collect(Collectors.toList());
     }
 
@@ -54,16 +54,16 @@ public class AWSService {
     /**
      * @return A list of available AWS services supported by the AWS Graylog AWS integration.
      */
-    public AvailableAWSServiceSummmary getAvailableServices() {
+    public AvailableServiceResponse getAvailableServices() {
 
-        ArrayList<AvailableAWSService> services = new ArrayList<>();
-        AvailableAWSService cloudWatchService =
-                AvailableAWSService.create("CloudWatch",
+        ArrayList<AvailableService> services = new ArrayList<>();
+        AvailableService cloudWatchService =
+                AvailableService.create("CloudWatch",
                                            "Retrieve CloudWatch logs via Kinesis. Kinesis allows streaming of the logs " +
                                                    "in real time. AWS CloudWatch is a monitoring and management service built " +
                                                    "for developers, system operators, site reliability engineers (SRE), " +
                                                    "and IT managers.",
-                                           "{\n" +
+                                        "{\n" +
                                                    "  \"Version\": \"2019-06-19\",\n" +
                                                    "  \"Statement\": [\n" +
                                                    "    {\n" +
@@ -90,10 +90,10 @@ public class AWSService {
                                                    "    }\n" +
                                                    "  ]\n" +
                                                    "}",
-                                           "Requires Kinesis",
-                                           "https://aws.amazon.com/cloudwatch/"
+                                        "Requires Kinesis",
+                                        "https://aws.amazon.com/cloudwatch/"
                 );
         services.add(cloudWatchService);
-        return AvailableAWSServiceSummmary.create(services, services.size());
+        return AvailableServiceResponse.create(services, services.size());
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/service/CloudWatchService.java
+++ b/src/main/java/org/graylog/integrations/aws/service/CloudWatchService.java
@@ -1,5 +1,8 @@
 package org.graylog.integrations.aws.service;
 
+import org.graylog.integrations.aws.resources.responses.LogGroupsResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClientBuilder;
@@ -12,6 +15,8 @@ import java.util.ArrayList;
 
 public class CloudWatchService {
 
+    private static final Logger LOG = LoggerFactory.getLogger(CloudWatchService.class);
+
     private CloudWatchLogsClientBuilder logsClientBuilder;
 
     @Inject
@@ -19,15 +24,24 @@ public class CloudWatchService {
         this.logsClientBuilder = logsClientBuilder;
     }
 
+    private CloudWatchLogsClient createClient(String regionName, String accessKeyId, String secretAccessKey) {
+
+        return logsClientBuilder.region(Region.of(regionName))
+                                .credentialsProvider(AWSService.buildCredentialProvider(accessKeyId, secretAccessKey))
+                                .build();
+    }
+
     /**
      * Returns a list of log groups that exist in CloudWatch.
      *
-     * @param region The AWS region
+     * @param region             The AWS region
+     * @param awsAccessKeyId
+     * @param awsSecretAccessKey The AWS region
      * @return A list of log groups in alphabetical order.
      */
-    public ArrayList<String> getLogGroupNames(String region) {
+    public LogGroupsResponse getLogGroupNames(String region, String awsAccessKeyId, String awsSecretAccessKey) {
 
-        final CloudWatchLogsClient cloudWatchLogsClient = logsClientBuilder.region(Region.of(region)).build();
+        final CloudWatchLogsClient cloudWatchLogsClient = createClient(region, awsAccessKeyId, awsSecretAccessKey);
         final DescribeLogGroupsRequest describeLogGroupsRequest = DescribeLogGroupsRequest.builder().build();
         final DescribeLogGroupsIterable responses = cloudWatchLogsClient.describeLogGroupsPaginator(describeLogGroupsRequest);
 
@@ -37,6 +51,7 @@ public class CloudWatchService {
                 groupNameList.add(response.logGroups().get(c).logGroupName());
             }
         }
-        return groupNameList;
+        LOG.debug("Log groups queried: [{}]", groupNameList);
+        return LogGroupsResponse.create(groupNameList, groupNameList.size());
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/service/KinesisService.java
+++ b/src/main/java/org/graylog/integrations/aws/service/KinesisService.java
@@ -15,7 +15,8 @@ import org.graylog.integrations.aws.AWSLogMessage;
 import org.graylog.integrations.aws.cloudwatch.CloudWatchLogEntry;
 import org.graylog.integrations.aws.cloudwatch.CloudWatchLogSubscriptionData;
 import org.graylog.integrations.aws.resources.requests.KinesisHealthCheckRequest;
-import org.graylog.integrations.aws.resources.responses.KinesisHealthCheckResponse;
+import org.graylog.integrations.aws.resources.responses.HealthCheckResponse;
+import org.graylog.integrations.aws.resources.responses.StreamsResponse;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.configuration.Configuration;
@@ -95,24 +96,24 @@ public class KinesisService {
      * @return a {@code KinesisHealthCheckResponse}, which indicates the type of detected message and a sample parsed
      * message.
      */
-    public KinesisHealthCheckResponse healthCheck(KinesisHealthCheckRequest request) throws ExecutionException, IOException {
+    public HealthCheckResponse healthCheck(KinesisHealthCheckRequest request) throws ExecutionException, IOException {
 
         LOG.debug("Executing healthCheck");
         LOG.debug("Requesting a list of streams to find out if the indicated stream exists.");
         // Get all the Kinesis streams that exist for a user and region
-        final List<String> kinesisStreams = getKinesisStreams(request.region(),
-                                                              request.awsAccessKeyId(),
-                                                              request.awsSecretAccessKey());
+        final StreamsResponse streamsResponse = getKinesisStreamNames(request.region(),
+                                                                      request.awsAccessKeyId(),
+                                                                      request.awsSecretAccessKey());
 
         // Check if Kinesis stream exists
-        final boolean streamExists = kinesisStreams.stream()
-                                                   .anyMatch(streamName -> streamName.equals(request.streamName()));
+        final boolean streamExists = streamsResponse.streams().stream()
+                                                    .anyMatch(streamName -> streamName.equals(request.streamName()));
         if (!streamExists) {
             String explanation = String.format("The requested stream [%s] was not found.", request.streamName());
             LOG.error(explanation);
-            return KinesisHealthCheckResponse.create(false,
-                                                     AWSLogMessage.Type.UNKNOWN.toString(),
-                                                     explanation, request.logGroupName());
+            return HealthCheckResponse.create(false,
+                                              AWSLogMessage.Type.UNKNOWN.toString(),
+                                              explanation, request.logGroupName());
         }
 
         LOG.debug("The stream [{}] exists", request.streamName());
@@ -125,9 +126,9 @@ public class KinesisService {
         if (records.size() == 0) {
             String explanation = "The Kinesis stream does not contain any messages.";
             LOG.error(explanation);
-            return KinesisHealthCheckResponse.create(false,
-                                                     AWSLogMessage.Type.UNKNOWN.toString(),
-                                                     explanation, request.logGroupName());
+            return HealthCheckResponse.create(false,
+                                              AWSLogMessage.Type.UNKNOWN.toString(),
+                                              explanation, request.logGroupName());
         }
 
         // Select random record from list, and check if the payload is compressed
@@ -146,7 +147,7 @@ public class KinesisService {
      * @param regionName The AWS region to query Kinesis stream names from.
      * @return A list of all available Kinesis streams in the supplied region.
      */
-    public List<String> getKinesisStreams(String regionName, String accessKeyId, String secretAccessKey) throws ExecutionException {
+    public StreamsResponse getKinesisStreamNames(String regionName, String accessKeyId, String secretAccessKey) throws ExecutionException {
 
         LOG.debug("List Kinesis streams for region [{}]", regionName);
 
@@ -187,7 +188,7 @@ public class KinesisService {
             }
         }
         LOG.debug("Kinesis streams queried: [{}]", streamNames);
-        return streamNames;
+        return StreamsResponse.create(streamNames, streamNames.size());
     }
 
     /**
@@ -219,7 +220,7 @@ public class KinesisService {
      * message.
      * @see <a href="https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html"/>
      */
-    private KinesisHealthCheckResponse handleCompressedMessages(KinesisHealthCheckRequest request, byte[] payloadBytes) throws IOException {
+    private HealthCheckResponse handleCompressedMessages(KinesisHealthCheckRequest request, byte[] payloadBytes) throws IOException {
         LOG.debug("The supplied payload is GZip compressed. Proceeding to decompress.");
 
         final byte[] bytes = Tools.decompressGzip(payloadBytes).getBytes();
@@ -241,9 +242,9 @@ public class KinesisService {
 
         if (!logEntryOptional.isPresent()) {
             LOG.debug("One log messages was successfully selected from the CloudWatch payload.");
-            return KinesisHealthCheckResponse.create(false,
-                                                     AWSLogMessage.Type.UNKNOWN.toString(),
-                                                     "The Kinesis stream does not contain any messages.", request.logGroupName());
+            return HealthCheckResponse.create(false,
+                                              AWSLogMessage.Type.UNKNOWN.toString(),
+                                              "The Kinesis stream does not contain any messages.", request.logGroupName());
         }
 
         return detectAndParseMessage(logEntryOptional.get().message(), request.streamName(), request.logGroupName());
@@ -313,7 +314,7 @@ public class KinesisService {
      * @param logGroupName The log group name.
      * @return A {@code KinesisHealthCheckResponse} with the fully parsed message and type.
      */
-    private KinesisHealthCheckResponse detectAndParseMessage(String logMessage, String streamName, String logGroupName) {
+    private HealthCheckResponse detectAndParseMessage(String logMessage, String streamName, String logGroupName) {
 
         LOG.debug("Attempting to detect the type of log message. message [{}] stream [{}] log group [{}].",
                   logMessage, streamName, logGroupName);
@@ -335,7 +336,7 @@ public class KinesisService {
         if (codecFactory == null) {
             final String explanation = String.format("A codec with name [%s] could not be found.", type.getCodecName());
             LOG.error(explanation);
-            return KinesisHealthCheckResponse.create(false, type.toString(), explanation, null);
+            return HealthCheckResponse.create(false, type.toString(), explanation, null);
         }
 
         // Parse the message with the selected codec.
@@ -349,24 +350,24 @@ public class KinesisService {
         } catch (JsonProcessingException e) {
             LOG.error("An error occurred decoding Flow Log message.", e);
             final String explanation = String.format("Message decoding failed. More information might be " +
-                                                             "available by enabling Debug logging. message [%s]", logMessage);
+                                                     "available by enabling Debug logging. message [%s]", logMessage);
             LOG.error(explanation);
-            return KinesisHealthCheckResponse.create(false, type.toString(), explanation, null);
+            return HealthCheckResponse.create(false, type.toString(), explanation, null);
         }
 
         // Check if parsing message returns null.
         if (fullyParsedMessage == null) {
             final String explanation = String.format("Message decoding failed. More information might be " +
-                                                       "available by enabling Debug logging. message [%s]", logMessage);
+                                                     "available by enabling Debug logging. message [%s]", logMessage);
             LOG.error(explanation);
-            return KinesisHealthCheckResponse.create(false, type.toString(), explanation, null);
+            return HealthCheckResponse.create(false, type.toString(), explanation, null);
         }
 
         LOG.debug("Successfully parsed message type [{}] with codec [{}].", type, type.getCodecName());
 
-        return KinesisHealthCheckResponse.create(true, awsLogMessage.detectLogMessageType().toString(),
-                                                 responseMessage,
-                                                 buildMessageSummary(fullyParsedMessage, logEvent.message()));
+        return HealthCheckResponse.create(true, awsLogMessage.detectLogMessageType().toString(),
+                                          responseMessage,
+                                          buildMessageSummary(fullyParsedMessage, logEvent.message()));
     }
 
     /**

--- a/src/test/java/org.graylog.integrations/aws/service/AWSServiceTest.java
+++ b/src/test/java/org.graylog.integrations/aws/service/AWSServiceTest.java
@@ -1,7 +1,7 @@
 package org.graylog.integrations.aws.service;
 
+import org.graylog.integrations.aws.resources.responses.AWSRegion;
 import org.graylog.integrations.aws.resources.responses.AvailableServiceResponse;
-import org.graylog.integrations.aws.resources.responses.RegionsResponse;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,24 +22,22 @@ public class AWSServiceTest {
     @Test
     public void regionTest() {
 
-        List<RegionsResponse> availableRegions = awsService.getAvailableRegions();
+        List<AWSRegion> regions = awsService.getAvailableRegions().regions();
 
         // Use a loop presence check.
         // Check format of random region.
         boolean foundEuWestRegion = false;
-        for (RegionsResponse availableRegion : availableRegions) {
+        for (AWSRegion availableAWSRegion : regions) {
 
-            if (availableRegion.regionId().equals("eu-west-2")) {
+            if (availableAWSRegion.regionId().equals("eu-west-2")) {
                 foundEuWestRegion = true;
             }
         }
         assertTrue(foundEuWestRegion);
 
         // Use one liner presence checks.
-        assertTrue(availableRegions.stream().anyMatch(r -> r.regionDescription().equals("EU (Stockholm)")));
-        assertTrue(availableRegions.stream().anyMatch(r -> r.displayValue().equals("EU (Stockholm): eu-north-1")));
-        assertEquals("There should be 20 total regions. This will change in future versions of the AWS SDK",
-                     20, availableRegions.size());
+        assertTrue(regions.stream().anyMatch(r -> r.displayValue().equals("EU (Stockholm): eu-north-1")));
+        assertEquals("There should be 20 total regions. This will change in future versions of the AWS SDK", 20, regions.size());
     }
 
     @Test

--- a/src/test/java/org.graylog.integrations/aws/service/AWSServiceTest.java
+++ b/src/test/java/org.graylog.integrations/aws/service/AWSServiceTest.java
@@ -1,7 +1,7 @@
 package org.graylog.integrations.aws.service;
 
-import org.graylog.integrations.aws.resources.responses.AvailableAWSServiceSummmary;
-import org.graylog.integrations.aws.resources.responses.RegionResponse;
+import org.graylog.integrations.aws.resources.responses.AvailableServiceResponse;
+import org.graylog.integrations.aws.resources.responses.RegionsResponse;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,12 +22,12 @@ public class AWSServiceTest {
     @Test
     public void regionTest() {
 
-        List<RegionResponse> availableRegions = awsService.getAvailableRegions();
+        List<RegionsResponse> availableRegions = awsService.getAvailableRegions();
 
         // Use a loop presence check.
         // Check format of random region.
         boolean foundEuWestRegion = false;
-        for (RegionResponse availableRegion : availableRegions) {
+        for (RegionsResponse availableRegion : availableRegions) {
 
             if (availableRegion.regionId().equals("eu-west-2")) {
                 foundEuWestRegion = true;
@@ -45,7 +45,7 @@ public class AWSServiceTest {
     @Test
     public void testAvailableServices() {
 
-        AvailableAWSServiceSummmary services = awsService.getAvailableServices();
+        AvailableServiceResponse services = awsService.getAvailableServices();
 
         // There should be one service.
         assertEquals(1, services.total());


### PR DESCRIPTION
The `AWSResource.getLogGroupNames` and `AWSResource.getKinesisStreams` API resource methods now require a POST body with region and AWS credentials. Before, these methods were using implicit environment variable credentials.