### PR TITLE
Allow optional Log Group and Stream

### DIFF
--- a/src/main/java/org/graylog/integrations/aws/cloudwatch/CloudWatchLogEntry.java
+++ b/src/main/java/org/graylog/integrations/aws/cloudwatch/CloudWatchLogEntry.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 
-import javax.annotation.Nullable;
+import java.util.Optional;
 
 @JsonAutoDetect
 @AutoValue
@@ -19,15 +19,17 @@ public abstract class CloudWatchLogEntry {
     private static final String MESSAGE = "message";
 
     /**
-     * Log Group is optional, since messages may have been written directly to Kinesis without using CloudWatch.
-     * Only CloudWatch messages written VIA Kinesis CloudWatch subscriptions will contain a log group.
+     * CloudWatch Log Group and Log Stream are optional, since messages may have been written directly to Kinesis
+     * without using CloudWatch. Only CloudWatch messages written VIA Kinesis CloudWatch subscriptions will
+     * contain a log group and stream.
+     *
+     * @see <a href="https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html">Using CloudWatch Logs Subscription Filters</a>
      */
-    @Nullable
     @JsonProperty(LOG_GROUP)
-    public abstract String logGroup();
+    public abstract Optional<String> logGroup();
 
     @JsonProperty(LOG_STREAM)
-    public abstract String logStream();
+    public abstract Optional<String> logStream();
 
     @JsonProperty(TIMESTAMP)
     public abstract long timestamp();
@@ -40,6 +42,7 @@ public abstract class CloudWatchLogEntry {
                                             @JsonProperty(LOG_STREAM) String logStream,
                                             @JsonProperty(TIMESTAMP) long timestamp,
                                             @JsonProperty(MESSAGE) String message) {
-        return new AutoValue_CloudWatchLogEntry(logGroup, logStream, timestamp, message);
+        return new AutoValue_CloudWatchLogEntry(new Optional<>(logGroup), new Optional<>(logStream),
+                                                timestamp, message);
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/cloudwatch/CloudWatchLogEntry.java
+++ b/src/main/java/org/graylog/integrations/aws/cloudwatch/CloudWatchLogEntry.java
@@ -42,7 +42,7 @@ public abstract class CloudWatchLogEntry {
                                             @JsonProperty(LOG_STREAM) String logStream,
                                             @JsonProperty(TIMESTAMP) long timestamp,
                                             @JsonProperty(MESSAGE) String message) {
-        return new AutoValue_CloudWatchLogEntry(new Optional<>(logGroup), new Optional<>(logStream),
+        return new AutoValue_CloudWatchLogEntry(Optional.of(logGroup), Optional.of(logStream),
                                                 timestamp, message);
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/cloudwatch/CloudWatchLogEntry.java
+++ b/src/main/java/org/graylog/integrations/aws/cloudwatch/CloudWatchLogEntry.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 
+import javax.annotation.Nullable;
+
 @JsonAutoDetect
 @AutoValue
 @WithBeanGetter
@@ -16,6 +18,11 @@ public abstract class CloudWatchLogEntry {
     private static final String TIMESTAMP = "timestamp";
     private static final String MESSAGE = "message";
 
+    /**
+     * Log Group is optional, since messages may have been written directly to Kinesis without using CloudWatch.
+     * Only CloudWatch messages written VIA Kinesis CloudWatch subscriptions will contain a log group.
+     */
+    @Nullable
     @JsonProperty(LOG_GROUP)
     public abstract String logGroup();
 

--- a/src/main/java/org/graylog/integrations/aws/codec/CloudWatchFlowLogCodec.java
+++ b/src/main/java/org/graylog/integrations/aws/codec/CloudWatchFlowLogCodec.java
@@ -34,7 +34,7 @@ public class CloudWatchFlowLogCodec extends CloudWatchLogDataCodec {
 
     @Nullable
     @Override
-    public Message decodeLogData(@Nonnull final CloudWatchLogEntry logEvent, @Nonnull final String logGroup, @Nonnull final String logStream) {
+    public Message decodeLogData(@Nonnull final CloudWatchLogEntry logEvent) {
         try {
             final FlowLogMessage flowLogMessage = FlowLogMessage.fromLogEvent(logEvent);
 
@@ -49,8 +49,10 @@ public class CloudWatchFlowLogCodec extends CloudWatchLogDataCodec {
                     flowLogMessage.getTimestamp()
             );
             result.addFields(buildFields(flowLogMessage));
-            result.addField(AWSUtils.FIELD_LOG_GROUP, logGroup);
-            result.addField(AWSUtils.FIELD_LOG_STREAM, logStream);
+
+            logEvent.logGroup().ifPresent(group -> result.addField(AWSUtils.FIELD_LOG_GROUP, group));
+            logEvent.logStream().ifPresent(stream -> result.addField(AWSUtils.FIELD_LOG_STREAM, stream));
+
             result.addField(AWSUtils.SOURCE_GROUP_IDENTIFIER, true);
 
             return result;

--- a/src/main/java/org/graylog/integrations/aws/codec/CloudWatchLogDataCodec.java
+++ b/src/main/java/org/graylog/integrations/aws/codec/CloudWatchLogDataCodec.java
@@ -29,9 +29,8 @@ public abstract class CloudWatchLogDataCodec extends AbstractCodec {
     public Message decode(@Nonnull RawMessage rawMessage) {
         try {
             final CloudWatchLogEntry entry = objectMapper.readValue(rawMessage.getPayload(), CloudWatchLogEntry.class);
-
             try {
-                return decodeLogData(entry, entry.logGroup(), entry.logStream());
+                return decodeLogData(entry);
             } catch (Exception e) {
                 LOG.error("Couldn't decode log event <{}>", entry);
 
@@ -44,7 +43,7 @@ public abstract class CloudWatchLogDataCodec extends AbstractCodec {
     }
 
     @Nullable
-    protected abstract Message decodeLogData(@Nonnull final CloudWatchLogEntry event, @Nonnull final String logGroup, @Nonnull final String logStream);
+    protected abstract Message decodeLogData(@Nonnull final CloudWatchLogEntry entry);
 
     @Nonnull
     @Override

--- a/src/main/java/org/graylog/integrations/aws/codec/CloudWatchRawLogCodec.java
+++ b/src/main/java/org/graylog/integrations/aws/codec/CloudWatchRawLogCodec.java
@@ -26,7 +26,7 @@ public class CloudWatchRawLogCodec extends CloudWatchLogDataCodec {
 
     @Nullable
     @Override
-    public Message decodeLogData(@Nonnull final CloudWatchLogEntry logEvent, @Nonnull final String logGroup, @Nonnull final String logStream) {
+    public Message decodeLogData(@Nonnull final CloudWatchLogEntry logEvent) {
         try {
             final String source = configuration.getString(CloudWatchFlowLogCodec.Config.CK_OVERRIDE_SOURCE, "aws-raw-logs");
             Message result = new Message(
@@ -34,8 +34,9 @@ public class CloudWatchRawLogCodec extends CloudWatchLogDataCodec {
                     source,
                     new DateTime(logEvent.timestamp())
             );
-            result.addField(AWSUtils.FIELD_LOG_GROUP, logGroup);
-            result.addField(AWSUtils.FIELD_LOG_STREAM, logStream);
+
+            logEvent.logGroup().ifPresent(group -> result.addField(AWSUtils.FIELD_LOG_GROUP, group));
+            logEvent.logStream().ifPresent(stream -> result.addField(AWSUtils.FIELD_LOG_STREAM, stream));
 
             return result;
         } catch (Exception e) {

--- a/src/test/java/org.graylog.integrations/aws/codec/CloudWatchFlowLogCodecTest.java
+++ b/src/test/java/org.graylog.integrations/aws/codec/CloudWatchFlowLogCodecTest.java
@@ -27,7 +27,7 @@ public class CloudWatchFlowLogCodecTest {
 
         String flowLogMessage = "2 423432432432 eni-3244234 172.1.1.2 172.1.1.2 80 2264 6 1 52 1559738144 1559738204 ACCEPT OK";
         final CloudWatchLogEntry logEvent = CloudWatchLogEntry.create("logGroup", "logStream", DateTime.now().getMillis() / 1000, flowLogMessage);
-        Message message = codec.decodeLogData(logEvent, logEvent.logGroup(), logEvent.logStream());
+        Message message = codec.decodeLogData(logEvent);
 
         Assert.assertEquals("logGroup", message.getField("aws_log_group"));
         Assert.assertEquals("logStream", message.getField("aws_log_stream"));


### PR DESCRIPTION
CloudWatch Log Group and Log Stream are optional, since messages may have been written directly to Kinesis without using CloudWatch. Only CloudWatch messages written VIA Kinesis CloudWatch subscriptions will contain a log group and stream.

`Optional.ifPresent` is used since field assignment is still conditionally required see:
https://github.com/Graylog2/graylog-plugin-integrations/blob/21c41377090a36907510d78f4bc87387db396377/src/main/java/org/graylog/integrations/aws/codec/CloudWatchFlowLogCodec.java#L53).