### PR TITLE
Return JSON message field list in response from Health Check

### DIFF
--- a/src/main/java/org/graylog/integrations/aws/AWSMessageType.java
+++ b/src/main/java/org/graylog/integrations/aws/AWSMessageType.java
@@ -1,5 +1,6 @@
 package org.graylog.integrations.aws;
 
+import org.graylog.integrations.aws.codecs.KinesisCloudWatchFlowLogCodec;
 import org.graylog.integrations.aws.codecs.KinesisRawLogCodec;
 import org.graylog.integrations.aws.transports.KinesisTransport;
 import org.graylog2.plugin.inputs.codecs.AbstractCodec;
@@ -21,8 +22,8 @@ public enum AWSMessageType {
                 AbstractCodec.Factory.class, KinesisTransport.Factory.class),
 
     // Flow Logs delivered to Kinesis via CloudWatch subscriptions.
-    KINESIS_FLOW_LOGS(Source.KINESIS, "Flow Log", KinesisRawLogCodec.NAME,
-                      KinesisRawLogCodec.Factory.class, KinesisTransport.Factory.class),
+    KINESIS_FLOW_LOGS(Source.KINESIS, "Flow Log", KinesisCloudWatchFlowLogCodec.NAME,
+                      KinesisCloudWatchFlowLogCodec.Factory.class, KinesisTransport.Factory.class),
 
     UNKNOWN();
 

--- a/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
@@ -11,7 +11,7 @@ import org.graylog.integrations.aws.resources.requests.AWSInputCreateRequest;
 import org.graylog.integrations.aws.resources.requests.AWSRequestImpl;
 import org.graylog.integrations.aws.resources.requests.KinesisHealthCheckRequest;
 import org.graylog.integrations.aws.resources.responses.AvailableServiceResponse;
-import org.graylog.integrations.aws.resources.responses.HealthCheckResponse;
+import org.graylog.integrations.aws.resources.responses.KinesisHealthCheckResponse;
 import org.graylog.integrations.aws.resources.responses.LogGroupsResponse;
 import org.graylog.integrations.aws.resources.responses.RegionsResponse;
 import org.graylog.integrations.aws.resources.responses.StreamsResponse;
@@ -153,11 +153,11 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
     @Path("/kinesis/health_check")
     @ApiOperation(
             value = "Attempt to retrieve logs from the indicated AWS log group with the specified credentials.",
-            response = HealthCheckResponse.class
+            response = KinesisHealthCheckResponse.class
     )
     @RequiresPermissions(AWSPermissions.AWS_READ)
     public Response kinesisHealthCheck(@ApiParam(name = "JSON body", required = true) @Valid @NotNull KinesisHealthCheckRequest heathCheckRequest) throws ExecutionException, IOException {
-        HealthCheckResponse response = kinesisService.healthCheck(heathCheckRequest);
+        KinesisHealthCheckResponse response = kinesisService.healthCheck(heathCheckRequest);
         return Response.accepted().entity(response).build();
     }
 

--- a/src/main/java/org/graylog/integrations/aws/resources/responses/HealthCheckResponse.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/responses/HealthCheckResponse.java
@@ -7,7 +7,8 @@ import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 import org.graylog.integrations.aws.AWSMessageType;
 
-import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
 
 @JsonAutoDetect
 @AutoValue
@@ -17,7 +18,7 @@ public abstract class HealthCheckResponse {
     private static final String SUCCESS = "success";
     private static final String INPUT_TYPE = "input_type";
     private static final String EXPLANATION = "explanation";
-    private static final String MESSAGE_SUMMARY = "message_summary";
+    private static final String message_fields = "message_fields";
 
     @JsonProperty(SUCCESS)
     public abstract boolean success();
@@ -33,14 +34,14 @@ public abstract class HealthCheckResponse {
     // A JSON representation of the message. This will be displayed in the UI to show the user
     // that we have identified the message type. The user can then verify that the parsed
     // message looks correct.
-    @JsonProperty(MESSAGE_SUMMARY)
-    public abstract String messageSummary();
+    @JsonProperty(message_fields)
+    public abstract Map<String,Object> messageSummary();
 
     public static HealthCheckResponse create(@JsonProperty(SUCCESS) boolean success,
                                              @JsonProperty(INPUT_TYPE) AWSMessageType inputType,
                                              @JsonProperty(EXPLANATION) String explanation,
-                                             @JsonProperty(MESSAGE_SUMMARY) String messageSummary) {
-        return new AutoValue_HealthCheckResponse(success, inputType, explanation, messageSummary);
+                                             @JsonProperty(message_fields) Map<String, Object> messagefields) {
+        return new AutoValue_HealthCheckResponse(success, inputType, explanation, messagefields);
     }
 
     /**
@@ -48,6 +49,6 @@ public abstract class HealthCheckResponse {
      * @return a {@link HealthCheckResponse} instance
      */
     public static HealthCheckResponse createFailed(@JsonProperty(EXPLANATION) String explanation) {
-        return new AutoValue_HealthCheckResponse(false, AWSMessageType.UNKNOWN, explanation, "");
+        return new AutoValue_HealthCheckResponse(false, AWSMessageType.UNKNOWN, explanation, new HashMap<>());
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/resources/responses/KinesisHealthCheckResponse.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/responses/KinesisHealthCheckResponse.java
@@ -13,12 +13,12 @@ import java.util.Map;
 @JsonAutoDetect
 @AutoValue
 @WithBeanGetter
-public abstract class HealthCheckResponse {
+public abstract class KinesisHealthCheckResponse {
 
     private static final String SUCCESS = "success";
     private static final String INPUT_TYPE = "input_type";
     private static final String EXPLANATION = "explanation";
-    private static final String message_fields = "message_fields";
+    private static final String MESSAGE_FIELDS = "message_fields";
 
     @JsonProperty(SUCCESS)
     public abstract boolean success();
@@ -34,21 +34,21 @@ public abstract class HealthCheckResponse {
     // A JSON representation of the message. This will be displayed in the UI to show the user
     // that we have identified the message type. The user can then verify that the parsed
     // message looks correct.
-    @JsonProperty(message_fields)
-    public abstract Map<String,Object> messageSummary();
+    @JsonProperty(MESSAGE_FIELDS)
+    public abstract Map<String,Object> messageFields();
 
-    public static HealthCheckResponse create(@JsonProperty(SUCCESS) boolean success,
-                                             @JsonProperty(INPUT_TYPE) AWSMessageType inputType,
-                                             @JsonProperty(EXPLANATION) String explanation,
-                                             @JsonProperty(message_fields) Map<String, Object> messagefields) {
-        return new AutoValue_HealthCheckResponse(success, inputType, explanation, messagefields);
+    public static KinesisHealthCheckResponse create(@JsonProperty(SUCCESS) boolean success,
+                                                    @JsonProperty(INPUT_TYPE) AWSMessageType inputType,
+                                                    @JsonProperty(EXPLANATION) String explanation,
+                                                    @JsonProperty(MESSAGE_FIELDS) Map<String, Object> messageFields) {
+        return new AutoValue_KinesisHealthCheckResponse(success, inputType, explanation, messageFields);
     }
 
     /**
      * Create failed/unknown message type response.
-     * @return a {@link HealthCheckResponse} instance
+     * @return a {@link KinesisHealthCheckResponse} instance
      */
-    public static HealthCheckResponse createFailed(@JsonProperty(EXPLANATION) String explanation) {
-        return new AutoValue_HealthCheckResponse(false, AWSMessageType.UNKNOWN, explanation, new HashMap<>());
+    public static KinesisHealthCheckResponse createFailed(@JsonProperty(EXPLANATION) String explanation) {
+        return new AutoValue_KinesisHealthCheckResponse(false, AWSMessageType.UNKNOWN, explanation, new HashMap<>());
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/service/KinesisService.java
+++ b/src/main/java/org/graylog/integrations/aws/service/KinesisService.java
@@ -373,44 +373,7 @@ public class KinesisService {
 
         return HealthCheckResponse.create(true, awsMessageType,
                                           responseMessage,
-                                          buildMessageSummary(fullyParsedMessage, logEvent.message()));
-    }
-
-    /**
-     * Prepare a string summary of all fields. This wil be displayed on the Health Check results page.
-     * The purpose is to provide the user with a summary of the parsed fields.
-     * <p>
-     * Note that the {@code org.graylog2.plugin.Message.toString()} method is not suitable for this, since it is a
-     * one-line summary. Multi-line is important for clarity.
-     *
-     * @param message     The fully parsed {@code org.graylog2.plugin.Message} object.
-     * @param fullMessage The full, unparsed message string.
-     * @return a summary of fields in the following format:
-     * <p>
-     * full_message: 2 423432432432 eni-3244234 172.1.1.2 172.1.1.2 80 2264 6 1 52 1559738144 1559738204 ACCEPT OK
-     * protocol_number: 6
-     * src_addr: 172.1.1.2
-     * source: aws-flowlogs
-     * message: eni-3244234 ACCEPT TCP 172.1.1.2:80 -> 172.1.1.2:2264
-     * packets: 1
-     * ...
-     */
-    String buildMessageSummary(Message message, String fullMessage) {
-
-        // Build up a multi-line string representation of the message.
-        final StringBuilder builder = new StringBuilder();
-        final String cleanMessage = fullMessage.replaceAll("\\n", "").replaceAll("\\t", "");
-
-        // Append the entire message.
-        builder.append("full_message: ");
-        builder.append(StringUtils.abbreviate(cleanMessage, 225)); // Shorten if too long.
-
-        // Append the field values.
-        builder.append("\n");
-        final Map<String, Object> filteredFields = Maps.newHashMap(message.getFields());
-        Joiner.on("\n").withKeyValueSeparator(": ").appendTo(builder, filteredFields);
-
-        return builder.toString();
+                                          fullyParsedMessage.getFields());
     }
 
     Record selectRandomRecord(List<Record> recordsList) {

--- a/src/test/java/org.graylog.integrations/aws/service/KinesisServiceTest.java
+++ b/src/test/java/org.graylog.integrations/aws/service/KinesisServiceTest.java
@@ -48,7 +48,6 @@ import java.util.zip.GZIPOutputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.when;
 
@@ -143,24 +142,30 @@ public class KinesisServiceTest {
     }
 
     @Test
-    public void healthCheckFlowLog() throws ExecutionException, IOException {
+    public void healthCheckCloudWatchFlowLog() throws ExecutionException, IOException {
 
         // The recordArrivalTime does not matter here, since the CloudWatch timestamp is used for the message instead.
         HealthCheckResponse response = executeHealthCheckTest(buildCloudWatchFlowLogPayload(),
                                                               Instant.now());
         assertEquals(AWSMessageType.KINESIS_FLOW_LOGS, response.inputType());
-        assertEquals(response.messageSummary().get("timestamp"),
-                     new DateTime("2019-06-05T12:35:44.000Z", DateTimeZone.UTC));
+        assertEquals(new DateTime("2019-06-05T12:35:44.000Z", DateTimeZone.UTC),
+                     response.messageSummary().get("timestamp"));
+        assertEquals(21, response.messageSummary().size());
+        assertEquals(6,response.messageSummary().get("protocol_number"));
+        assertEquals("TCP",response.messageSummary().get("protocol"));
+        assertEquals(1L,response.messageSummary().get("packets"));
+        assertEquals("172.1.1.2",response.messageSummary().get("dst_addr"));
     }
 
     @Test
-    public void healthCheckCloudWatchFlowLog() throws ExecutionException, IOException {
+    public void healthCheckCloudWatchRaw() throws ExecutionException, IOException {
 
         // The recordArrivalTime does not matter here, since the CloudWatch timestamp is used for the message instead.
         HealthCheckResponse response = executeHealthCheckTest(buildCloudWatchRawPayload(), Instant.now());
         assertEquals(AWSMessageType.KINESIS_RAW, response.inputType());
-        assertEquals(response.messageSummary().get("timestamp"),
-                     new DateTime("2019-06-05T12:35:44.000Z", DateTimeZone.UTC));
+        assertEquals(new DateTime("2019-06-05T12:35:44.000Z", DateTimeZone.UTC),
+                     response.messageSummary().get("timestamp"));
+        assertEquals(7, response.messageSummary().size());
     }
 
     @Test
@@ -171,8 +176,9 @@ public class KinesisServiceTest {
         Instant logArrivalTime = Instant.ofEpochMilli(new DateTime(2000, 1, 1, 1, 1, 1, DateTimeZone.UTC).getMillis());
         HealthCheckResponse response = executeHealthCheckTest("This is a test raw log".getBytes(), logArrivalTime);
         assertEquals(AWSMessageType.KINESIS_RAW, response.inputType());
-        assertEquals(response.messageSummary().get("timestamp"),
-                     new DateTime("2000-01-01T01:01:01.000Z", DateTimeZone.UTC));
+        assertEquals(new DateTime("2000-01-01T01:01:01.000Z", DateTimeZone.UTC),
+                     response.messageSummary().get("timestamp"));
+        assertEquals(5, response.messageSummary().size());
     }
 
     private HealthCheckResponse executeHealthCheckTest(byte[] payloadData, Instant recordArrivalTime) throws IOException, ExecutionException {

--- a/src/test/java/org.graylog.integrations/aws/service/KinesisServiceTest.java
+++ b/src/test/java/org.graylog.integrations/aws/service/KinesisServiceTest.java
@@ -333,23 +333,6 @@ public class KinesisServiceTest {
         assertEquals(4, streamsResponse.streams().size());
     }
 
-    // TODO Add retrieveRecords test
-
-    @Test
-    public void testMessageFormat() {
-
-        HashMap<String, Object> fields = new HashMap<>();
-        fields.put("_id", "123");
-        fields.put("src_addr", "Dan");
-        fields.put("port", 80);
-
-        String summary = kinesisService.buildMessageSummary(new Message(fields), "The full message");
-        assertEquals("The summary should have 4 lines", 4, summary.split("\n").length);
-        assertTrue(summary.contains("id"));
-        assertTrue(summary.contains("src_addr"));
-        assertTrue(summary.contains("port"));
-    }
-
     @Test
     public void testSelectRandomRecord() {
 

--- a/src/test/java/org.graylog.integrations/aws/service/KinesisServiceTest.java
+++ b/src/test/java/org.graylog.integrations/aws/service/KinesisServiceTest.java
@@ -9,7 +9,6 @@ import org.graylog.integrations.aws.codecs.KinesisRawLogCodec;
 import org.graylog.integrations.aws.resources.requests.KinesisHealthCheckRequest;
 import org.graylog.integrations.aws.resources.responses.HealthCheckResponse;
 import org.graylog.integrations.aws.resources.responses.StreamsResponse;
-import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.inputs.codecs.Codec;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
@@ -150,7 +149,8 @@ public class KinesisServiceTest {
         HealthCheckResponse response = executeHealthCheckTest(buildCloudWatchFlowLogPayload(),
                                                               Instant.now());
         assertEquals(AWSMessageType.KINESIS_FLOW_LOGS, response.inputType());
-        assertTrue(response.messageSummary().contains("timestamp: 2019-06-05T12:35:44.000Z"));
+        assertEquals(response.messageSummary().get("timestamp"),
+                     new DateTime("2019-06-05T12:35:44.000Z", DateTimeZone.UTC));
     }
 
     @Test
@@ -159,7 +159,8 @@ public class KinesisServiceTest {
         // The recordArrivalTime does not matter here, since the CloudWatch timestamp is used for the message instead.
         HealthCheckResponse response = executeHealthCheckTest(buildCloudWatchRawPayload(), Instant.now());
         assertEquals(AWSMessageType.KINESIS_RAW, response.inputType());
-        assertTrue(response.messageSummary().contains("timestamp: 2019-06-05T12:35:44.000Z"));
+        assertEquals(response.messageSummary().get("timestamp"),
+                     new DateTime("2019-06-05T12:35:44.000Z", DateTimeZone.UTC));
     }
 
     @Test
@@ -170,7 +171,8 @@ public class KinesisServiceTest {
         Instant logArrivalTime = Instant.ofEpochMilli(new DateTime(2000, 1, 1, 1, 1, 1, DateTimeZone.UTC).getMillis());
         HealthCheckResponse response = executeHealthCheckTest("This is a test raw log".getBytes(), logArrivalTime);
         assertEquals(AWSMessageType.KINESIS_RAW, response.inputType());
-        assertTrue(response.messageSummary().contains("timestamp: 2000-01-01T01:01:01.000Z"));
+        assertEquals(response.messageSummary().get("timestamp"),
+                     new DateTime("2000-01-01T01:01:01.000Z", DateTimeZone.UTC));
     }
 
     private HealthCheckResponse executeHealthCheckTest(byte[] payloadData, Instant recordArrivalTime) throws IOException, ExecutionException {


### PR DESCRIPTION
This changes the Health Check response to return a list of message fields instead of the text summary. Resolves #109

New example response:
```
{
  "success": true,
  "input_type": "KINESIS_FLOW_LOGS",
  "explanation": "Success. The message is a Flow Log message.",
  "message_fields": {
    "protocol_number": 6,
    "src_addr": "172.1.1.2",
    "source": "aws-flowlogs",
    "message": "eni-3244234 ACCEPT TCP 172.1.1.2:80 -> 172.1.1.2:2264",
    "dst_addr": "172.1.1.2",
    "dst_port": 2264,
    "action": "ACCEPT",
    "_id": "4ecfcb60-9913-11e9-a3a6-32ca2bdd4771",
    "aws_log_stream": "eni-3423-all",
    "timestamp": "2019-06-05T12:35:44.000Z"
  }
}
```

The plan is to display these fields in a formatted way in the UI instead of in a big block of text.