### PR TITLE
Use standard field names for AWS key and secret

### DIFF
--- a/src/main/java/org/graylog/integrations/aws/resources/requests/AWSInputCreateRequest.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/requests/AWSInputCreateRequest.java
@@ -84,10 +84,10 @@ public abstract class AWSInputCreateRequest implements AWSRequest {
                                                @JsonProperty(AWSRequest.AWS_ACCESS_KEY_ID) String awsAccessKey,
                                                @JsonProperty(AWSRequest.AWS_SECRET_ACCESS_KEY) String awsSecretKey,
                                                @JsonProperty(STREAM_NAME) String streamName,
-                                               @JsonProperty(REGION) String region,
+                                               @JsonProperty(AWSRequest.REGION) String region,
                                                @JsonProperty(BATCH_SIZE) int batchSize,
                                                @JsonProperty(ASSUME_ROLE_ARN) String assumeRoleArn,
-                                               @JsonProperty(AWSRequest.REGION) boolean global,
+                                               @JsonProperty(GLOBAL) boolean global,
                                                @JsonProperty(THROTTLING_ALLOWED) boolean enableThrottling,
                                                @JsonProperty(KINESIS_MAX_THROTTLED_WAIT_MS) int kinesisMaxThrottledWaitMs) {
         return new AutoValue_AWSInputCreateRequest(name, description, awsMessageType, awsAccessKey, awsSecretKey, streamName, assumeRoleArn, region, batchSize, global, enableThrottling, kinesisMaxThrottledWaitMs);

--- a/src/main/java/org/graylog/integrations/aws/resources/requests/AWSInputCreateRequest.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/requests/AWSInputCreateRequest.java
@@ -34,8 +34,6 @@ public abstract class AWSInputCreateRequest {
     private static final String NAME = "name";
     private static final String DESCRIPTION = "description";
     private static final String AWS_MESSAGE_TYPE = "aws_input_type";
-    private static final String AWS_ACCESS_KEY = "aws_access_key";
-    private static final String AWS_SECRET_KEY = "aws_secret_key";
     private static final String STREAM_NAME = "stream_name";
     private static final String REGION = "region";
     private static final String BATCH_SIZE = "batch_size";
@@ -53,10 +51,10 @@ public abstract class AWSInputCreateRequest {
     @JsonProperty(AWS_MESSAGE_TYPE)
     public abstract String awsMessageType();
 
-    @JsonProperty(AWS_ACCESS_KEY)
+    @JsonProperty(AWSRequest.AWS_ACCESS_KEY_ID)
     public abstract String awsAccessKey();
 
-    @JsonProperty(AWS_SECRET_KEY)
+    @JsonProperty(AWSRequest.AWS_SECRET_ACCESS_KEY)
     public abstract String awsSecretKey();
 
     @JsonProperty(STREAM_NAME)
@@ -84,8 +82,8 @@ public abstract class AWSInputCreateRequest {
     public static AWSInputCreateRequest create(@JsonProperty(NAME) String name,
                                                @JsonProperty(DESCRIPTION) String description,
                                                @JsonProperty(AWS_MESSAGE_TYPE) String awsMessageType,
-                                               @JsonProperty(AWS_ACCESS_KEY) String awsAccessKey,
-                                               @JsonProperty(AWS_SECRET_KEY) String awsSecretKey,
+                                               @JsonProperty(AWSRequest.AWS_ACCESS_KEY_ID) String awsAccessKey,
+                                               @JsonProperty(AWSRequest.AWS_SECRET_ACCESS_KEY) String awsSecretKey,
                                                @JsonProperty(STREAM_NAME) String streamName,
                                                @JsonProperty(REGION) String region,
                                                @JsonProperty(BATCH_SIZE) int batchSize,

--- a/src/main/java/org/graylog/integrations/aws/resources/requests/AWSInputCreateRequest.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/requests/AWSInputCreateRequest.java
@@ -29,13 +29,12 @@ import org.graylog.autovalue.WithBeanGetter;
 @JsonAutoDetect
 @AutoValue
 @WithBeanGetter
-public abstract class AWSInputCreateRequest {
+public abstract class AWSInputCreateRequest implements AWSRequest {
 
     private static final String NAME = "name";
     private static final String DESCRIPTION = "description";
     private static final String AWS_MESSAGE_TYPE = "aws_input_type";
     private static final String STREAM_NAME = "stream_name";
-    private static final String REGION = "region";
     private static final String BATCH_SIZE = "batch_size";
     private static final String ASSUME_ROLE_ARN = "assume_role_arn";
     private static final String GLOBAL = "global";
@@ -63,7 +62,7 @@ public abstract class AWSInputCreateRequest {
     @JsonProperty(ASSUME_ROLE_ARN)
     public abstract String assumeRoleARN();
 
-    @JsonProperty(REGION)
+    @JsonProperty(AWSRequest.REGION)
     public abstract String region();
 
     @JsonProperty(BATCH_SIZE)
@@ -88,7 +87,7 @@ public abstract class AWSInputCreateRequest {
                                                @JsonProperty(REGION) String region,
                                                @JsonProperty(BATCH_SIZE) int batchSize,
                                                @JsonProperty(ASSUME_ROLE_ARN) String assumeRoleArn,
-                                               @JsonProperty(GLOBAL) boolean global,
+                                               @JsonProperty(AWSRequest.REGION) boolean global,
                                                @JsonProperty(THROTTLING_ALLOWED) boolean enableThrottling,
                                                @JsonProperty(KINESIS_MAX_THROTTLED_WAIT_MS) int kinesisMaxThrottledWaitMs) {
         return new AutoValue_AWSInputCreateRequest(name, description, awsMessageType, awsAccessKey, awsSecretKey, streamName, assumeRoleArn, region, batchSize, global, enableThrottling, kinesisMaxThrottledWaitMs);

--- a/src/main/java/org/graylog/integrations/aws/resources/requests/AWSInputCreateRequest.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/requests/AWSInputCreateRequest.java
@@ -51,10 +51,10 @@ public abstract class AWSInputCreateRequest implements AWSRequest {
     public abstract String awsMessageType();
 
     @JsonProperty(AWSRequest.AWS_ACCESS_KEY_ID)
-    public abstract String awsAccessKey();
+    public abstract String awsAccessKeyId();
 
     @JsonProperty(AWSRequest.AWS_SECRET_ACCESS_KEY)
-    public abstract String awsSecretKey();
+    public abstract String awsSecretAccessKey();
 
     @JsonProperty(STREAM_NAME)
     public abstract String streamName();
@@ -90,6 +90,8 @@ public abstract class AWSInputCreateRequest implements AWSRequest {
                                                @JsonProperty(GLOBAL) boolean global,
                                                @JsonProperty(THROTTLING_ALLOWED) boolean enableThrottling,
                                                @JsonProperty(KINESIS_MAX_THROTTLED_WAIT_MS) int kinesisMaxThrottledWaitMs) {
-        return new AutoValue_AWSInputCreateRequest(name, description, awsMessageType, awsAccessKey, awsSecretKey, streamName, assumeRoleArn, region, batchSize, global, enableThrottling, kinesisMaxThrottledWaitMs);
+        return new AutoValue_AWSInputCreateRequest(name, description, awsMessageType, awsAccessKey, awsSecretKey,
+                                                   streamName, assumeRoleArn, region, batchSize, global,
+                                                   enableThrottling, kinesisMaxThrottledWaitMs);
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/service/AWSService.java
+++ b/src/main/java/org/graylog/integrations/aws/service/AWSService.java
@@ -176,8 +176,8 @@ public class AWSService {
         configuration.put(AWSInput.CK_GLOBAL, request.global());
         configuration.put(ThrottleableTransport.CK_THROTTLING_ALLOWED, request.throttlingAllowed());
         configuration.put(AWSInput.CK_AWS_REGION, request.region());
-        configuration.put(AWSInput.CK_ACCESS_KEY, request.awsAccessKey());
-        configuration.put(AWSInput.CK_SECRET_KEY, request.awsSecretKey());
+        configuration.put(AWSInput.CK_ACCESS_KEY, request.awsAccessKeyId());
+        configuration.put(AWSInput.CK_SECRET_KEY, request.awsSecretAccessKey());
         configuration.put(AWSInput.CK_ASSUME_ROLE_ARN, request.assumeRoleARN());
 
         AWSMessageType inputType = AWSMessageType.valueOf(request.awsMessageType());


### PR DESCRIPTION
Use these standard key/secret field names for AWS key and secret for the Save Input AWS endpoint (From the AWSRequest interface). All other AWS API requests should be using these already.
`aws_access_key_id` (previously `aws_access_key`)
`aws_secret_access_key` (previously `aws_secret_key`)

The region field was also changed to use the central `AWSRequest` constant. 