### PR TITLE
Form Field Error Handling

### DIFF
--- a/src/web/aws-cloudwatch/KinesisSetup.jsx
+++ b/src/web/aws-cloudwatch/KinesisSetup.jsx
@@ -17,6 +17,7 @@ const KinesisSetup = ({ onChange, onSubmit }) => {
         <FormWrap onSubmit={onSubmit}
                   buttonContent="Verify &amp; Format"
                   title="Create Kinesis Stream"
+                  disabled={false}
                   description="We&apos;re going to get started setting up your Kinesis Stream, just give us a name and choose the related CloudWatch Group. We&apos;ll handle the hard stuff!">
 
           <ValidatedInput id="awsCloudWatchKinesisStream"

--- a/src/web/aws-cloudwatch/KinesisSetup.jsx
+++ b/src/web/aws-cloudwatch/KinesisSetup.jsx
@@ -14,9 +14,10 @@ const KinesisSetup = ({ onChange, onSubmit }) => {
   return (
     <Row>
       <Col md={8}>
-        <FormWrap onSubmit={onSubmit} buttonContent="Verify &amp; Format">
-          <h2>Create Kinesis Stream</h2>
-          <p>We&apos;re going to get started setting up your Kinesis Stream, just give us a name and choose the related CloudWatch Group. We&apos;ll handle the hard stuff!</p>
+        <FormWrap onSubmit={onSubmit}
+                  buttonContent="Verify &amp; Format"
+                  title="Create Kinesis Stream"
+                  description="We&apos;re going to get started setting up your Kinesis Stream, just give us a name and choose the related CloudWatch Group. We&apos;ll handle the hard stuff!">
 
           <ValidatedInput id="awsCloudWatchKinesisStream"
                           type="text"

--- a/src/web/aws-cloudwatch/KinesisStreams.jsx
+++ b/src/web/aws-cloudwatch/KinesisStreams.jsx
@@ -37,9 +37,10 @@ const KinesisStreams = ({ onChange, onSubmit }) => {
       <Col md={8}>
         <FormWrap onSubmit={handleSubmit}
                   buttonContent="Verify Stream &amp; Format"
-                  loading={logSampleStatus.loading}>
-          <h2>Choose Kinesis Stream</h2>
-          <p>Below is a list of all Kinesis Streams found within the specified AWS account. Please choose the Stream you would like us to read messages from, or follow the directions to begin <a href={Routes.INTEGRATIONS.AWS.CLOUDWATCH.step('kinesis-setup')}>setting up your CloudWatch Log Group</a> to feed messages into a new Kinesis Stream.</p>
+                  loading={logSampleStatus.loading}
+                  disabled={false}
+                  title="Choose Kinesis Stream"
+                  description={<p>Below is a list of all Kinesis Streams found within the specified AWS account. Please choose the Stream you would like us to read messages from, or follow the directions to begin <a href={Routes.INTEGRATIONS.AWS.CLOUDWATCH.step('kinesis-setup')}>setting up your CloudWatch Log Group</a> to feed messages into a new Kinesis Stream.</p>}>
 
           <ValidatedInput id="awsCloudWatchKinesisStream"
                           type="select"

--- a/src/web/aws-cloudwatch/KinesisStreams.jsx
+++ b/src/web/aws-cloudwatch/KinesisStreams.jsx
@@ -11,6 +11,7 @@ import FormWrap from '../common/FormWrap';
 import ValidatedInput from '../common/ValidatedInput';
 import Routes, { ApiRoutes } from '../common/Routes';
 import { renderOptions } from '../common/Options';
+import formValidation from '../utils/formValidation';
 
 const KinesisStreams = ({ onChange, onSubmit }) => {
   const { formData } = useContext(FormDataContext);
@@ -38,7 +39,7 @@ const KinesisStreams = ({ onChange, onSubmit }) => {
         <FormWrap onSubmit={handleSubmit}
                   buttonContent="Verify Stream &amp; Format"
                   loading={logSampleStatus.loading}
-                  disabled={false}
+                  disabled={formValidation.isFormValid(['awsCloudWatchKinesisStream'], formData)}
                   title="Choose Kinesis Stream"
                   description={<p>Below is a list of all Kinesis Streams found within the specified AWS account. Please choose the Stream you would like us to read messages from, or follow the directions to begin <a href={Routes.INTEGRATIONS.AWS.CLOUDWATCH.step('kinesis-setup')}>setting up your CloudWatch Log Group</a> to feed messages into a new Kinesis Stream.</p>}>
 

--- a/src/web/aws-cloudwatch/StepAuthorize.jsx
+++ b/src/web/aws-cloudwatch/StepAuthorize.jsx
@@ -36,9 +36,10 @@ const StepAuthorize = ({ onChange, onSubmit }) => {
       <Col md={8}>
         <FormWrap onSubmit={handleSubmit}
                   buttonContent="Authorize &amp; Choose Stream"
-                  loading={fetchRegionsStatus.loading || fetchStreamsStatus.loading}>
-          <h2>Create Integration &amp; Authorize AWS</h2>
-          <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsum facere quis maiores doloribus asperiores modi dignissimos enim accusamus sunt aliquid, pariatur eligendi esse dolore temporibus corporis corrupti dolorum, soluta consectetur?</p>
+                  loading={fetchRegionsStatus.loading || fetchStreamsStatus.loading}
+                  disabled={false}
+                  title="Create Integration &amp; Authorize AWS"
+                  description="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsum facere quis maiores doloribus asperiores modi dignissimos enim accusamus sunt aliquid, pariatur eligendi esse dolore temporibus corporis corrupti dolorum, soluta consectetur?">
 
           {/* Fighting AutoComplete Forms */}
           <DisappearingInput id="name" type="text" />

--- a/src/web/aws-cloudwatch/StepAuthorize.jsx
+++ b/src/web/aws-cloudwatch/StepAuthorize.jsx
@@ -7,11 +7,11 @@ import { FormDataContext } from './context/FormData';
 import { ApiContext } from './context/Api';
 import useFetch from './hooks/useFetch';
 
-
 import ValidatedInput from '../common/ValidatedInput';
 import FormWrap from '../common/FormWrap';
 import { renderOptions } from '../common/Options';
 import { ApiRoutes } from '../common/Routes';
+import formValidation from '../utils/formValidation';
 
 const StepAuthorize = ({ onChange, onSubmit }) => {
   const { formData } = useContext(FormDataContext);
@@ -37,7 +37,12 @@ const StepAuthorize = ({ onChange, onSubmit }) => {
         <FormWrap onSubmit={handleSubmit}
                   buttonContent="Authorize &amp; Choose Stream"
                   loading={fetchRegionsStatus.loading || fetchStreamsStatus.loading}
-                  disabled={false}
+                  disabled={formValidation.isFormValid([
+                    'awsCloudWatchName',
+                    'awsCloudWatchAwsKey',
+                    'awsCloudWatchAwsSecret',
+                    'awsCloudWatchAwsRegion',
+                  ], formData)}
                   title="Create Integration &amp; Authorize AWS"
                   description="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsum facere quis maiores doloribus asperiores modi dignissimos enim accusamus sunt aliquid, pariatur eligendi esse dolore temporibus corporis corrupti dolorum, soluta consectetur?">
 

--- a/src/web/aws-cloudwatch/StepHealthCheck.jsx
+++ b/src/web/aws-cloudwatch/StepHealthCheck.jsx
@@ -14,9 +14,11 @@ const StepHealthCheck = ({ onSubmit }) => {
   return (
     <Row>
       <Col md={8}>
-        <FormWrap onSubmit={onSubmit} buttonContent="Review &amp; Finalize">
-          <h2>Create Kinesis Stream</h2>
-          <p>We&apos;re going to attempt to parse a single log to help you out! If we&apos;re unable to, or you would like it parsed differently, head on over to <a href="/system/pipelines">Pipeline Rules</a> to set up your own parser!</p>
+        <FormWrap onSubmit={onSubmit}
+                  buttonContent="Review &amp; Finalize"
+                  disabled={false}
+                  title="Create Kinesis Stream"
+                  description={<p>We&apos;re going to attempt to parse a single log to help you out! If we&apos;re unable to, or you would like it parsed differently, head on over to <a href="/system/pipelines">Pipeline Rules</a> to set up your own parser!</p>}>
 
           <span><i className="fa fa-smile-o fa-2x" /> Great! Looks like a well formatted Flow Log.</span>
 

--- a/src/web/aws-cloudwatch/StepHealthCheck.jsx
+++ b/src/web/aws-cloudwatch/StepHealthCheck.jsx
@@ -16,7 +16,6 @@ const StepHealthCheck = ({ onSubmit }) => {
       <Col md={8}>
         <FormWrap onSubmit={onSubmit}
                   buttonContent="Review &amp; Finalize"
-                  disabled={false}
                   title="Create Kinesis Stream"
                   description={<p>We&apos;re going to attempt to parse a single log to help you out! If we&apos;re unable to, or you would like it parsed differently, head on over to <a href="/system/pipelines">Pipeline Rules</a> to set up your own parser!</p>}>
 

--- a/src/web/aws-cloudwatch/StepHealthCheck.jsx
+++ b/src/web/aws-cloudwatch/StepHealthCheck.jsx
@@ -16,6 +16,7 @@ const StepHealthCheck = ({ onSubmit }) => {
       <Col md={8}>
         <FormWrap onSubmit={onSubmit}
                   buttonContent="Review &amp; Finalize"
+                  disabled={false}
                   title="Create Kinesis Stream"
                   description={<p>We&apos;re going to attempt to parse a single log to help you out! If we&apos;re unable to, or you would like it parsed differently, head on over to <a href="/system/pipelines">Pipeline Rules</a> to set up your own parser!</p>}>
 

--- a/src/web/aws-cloudwatch/StepReview.jsx
+++ b/src/web/aws-cloudwatch/StepReview.jsx
@@ -75,6 +75,7 @@ const StepReview = ({ onSubmit, onEditClick }) => {
         <FormWrap onSubmit={handleSubmit}
                   buttonContent="Complete CloudWatch Setup"
                   loading={fetchSubmitStatus.loading}
+                  disabled={false}
                   title="Final Review"
                   description="Check out everything below to make sure it&apos;s correct, then click the button below to complete your CloudWatch setup!">
 

--- a/src/web/aws-cloudwatch/StepReview.jsx
+++ b/src/web/aws-cloudwatch/StepReview.jsx
@@ -72,10 +72,12 @@ const StepReview = ({ onSubmit, onEditClick }) => {
   return (
     <Row>
       <Col md={8}>
-        <FormWrap onSubmit={handleSubmit} buttonContent="Complete CloudWatch Setup" loading={fetchSubmitStatus.loading}>
-          <h2>Final Review</h2>
-
-          <p>Check out everything below to make sure it&apos;s correct, then click the button below to complete your CloudWatch setup!</p>
+        <FormWrap onSubmit={handleSubmit}
+                  buttonContent="Complete CloudWatch Setup"
+                  loading={fetchSubmitStatus.loading}
+                  disabled={false}
+                  title="Final Review"
+                  description="Check out everything below to make sure it&apos;s correct, then click the button below to complete your CloudWatch setup!">
 
           <Container>
             <Subheader>Setting up CloudWatch <small><EditAnchor onClick={onEditClick('authorize')}>Edit</EditAnchor></small></Subheader>

--- a/src/web/aws-cloudwatch/StepReview.jsx
+++ b/src/web/aws-cloudwatch/StepReview.jsx
@@ -75,7 +75,6 @@ const StepReview = ({ onSubmit, onEditClick }) => {
         <FormWrap onSubmit={handleSubmit}
                   buttonContent="Complete CloudWatch Setup"
                   loading={fetchSubmitStatus.loading}
-                  disabled={false}
                   title="Final Review"
                   description="Check out everything below to make sure it&apos;s correct, then click the button below to complete your CloudWatch setup!">
 

--- a/src/web/aws-cloudwatch/context/default_settings.js
+++ b/src/web/aws-cloudwatch/context/default_settings.js
@@ -22,7 +22,9 @@ export const awsAuth = ({ awsCloudWatchAwsKey, awsCloudWatchAwsSecret }) => {
     This file is already set in .gitignore so it won't be commited
   */
 
-  const auth = { key: awsCloudWatchAwsKey.value, secret: awsCloudWatchAwsSecret.value };
+  const key = awsCloudWatchAwsKey ? awsCloudWatchAwsKey.value : '';
+  const secret = awsCloudWatchAwsSecret ? awsCloudWatchAwsSecret.value : '';
+  const auth = { key, secret };
 
   try {
     // eslint-disable-next-line global-require

--- a/src/web/common/FormWrap.jsx
+++ b/src/web/common/FormWrap.jsx
@@ -1,26 +1,42 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
 
-const FormWrap = ({ children, buttonContent, loading, onSubmit }) => {
-  const currentForm = useRef();
-  const isDisabled = loading || (currentForm.current && !currentForm.current.checkValidity());
+const FormWrap = ({
+  buttonContent,
+  children,
+  disabled,
+  description,
+  loading,
+  onSubmit,
+  title,
+}) => {
+  const formRef = useRef();
+  const [disabledButton, setDisabledButton] = useState(disabled);
   const prevent = (event) => {
     event.preventDefault();
     return false;
   };
 
+  useEffect(() => {
+    setDisabledButton(loading || disabled);
+  }, [loading, disabled]);
+
   return (
     <form onSubmit={prevent}
           autoComplete="off"
           noValidate
-          ref={currentForm}>
+          ref={formRef}>
+
+      {title && ((typeof (title) === 'string') ? <h2>{title}</h2> : title)}
+      {description && ((typeof (description) === 'string') ? <p>{description}</p> : description)}
+
       {children}
 
       <Button type="button"
-              onClick={onSubmit}
+              onClick={disabledButton ? null : onSubmit}
               bsStyle="primary"
-              disabled={isDisabled}>
+              disabled={disabledButton}>
         {loading ? 'Loading...' : buttonContent}
       </Button>
     </form>
@@ -28,19 +44,31 @@ const FormWrap = ({ children, buttonContent, loading, onSubmit }) => {
 };
 
 FormWrap.propTypes = {
-  children: PropTypes.any.isRequired,
-  onSubmit: PropTypes.func,
-  loading: PropTypes.bool,
   buttonContent: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]),
+  children: PropTypes.any.isRequired,
+  disabled: PropTypes.bool,
+  description: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]),
+  loading: PropTypes.bool,
+  onSubmit: PropTypes.func,
+  title: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.node,
   ]),
 };
 
 FormWrap.defaultProps = {
-  onSubmit: () => {},
   buttonContent: 'Submit',
+  disabled: true,
+  description: null,
   loading: false,
+  onSubmit: () => {},
+  title: null,
 };
 
 export default FormWrap;

--- a/src/web/common/ValidatedInput.jsx
+++ b/src/web/common/ValidatedInput.jsx
@@ -9,10 +9,10 @@ import formValidation from '../utils/formValidation';
 const Label = ({ label, error }) => {
   if (error) {
     return (
-      <React.Fragment>
+      <ErrorContainer>
         {label}
         <Error><i className="fa fa-exclamation-triangle" /> {error}</Error>
-      </React.Fragment>
+      </ErrorContainer>
     );
   }
 
@@ -73,6 +73,13 @@ ValidatedInput.defaultProps = {
 const Error = styled.span`
   display: block;
   font-weight: normal;
+  padding-left: 15px;
+  font-size: 0.85em;
+`;
+
+const ErrorContainer = styled.span`
+  display: flex;
+  align-items: center;
 `;
 
 export default ValidatedInput;

--- a/src/web/utils/formValidation.js
+++ b/src/web/utils/formValidation.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 const formValidation = {
   checkInputValidity: (input, customErrorMessage) => {
     const { validity } = input;
@@ -25,19 +23,13 @@ const formValidation = {
       { invalid: isInvalidStep, message: 'Unexpected value.' },
     ];
 
-    const errorOutput = _.find(possibleErrors, error => error.invalid);
+    const errorOutput = possibleErrors.find(error => error.invalid);
 
     return customErrorMessage || errorOutput.message;
   },
 
-  isFormValid: (form) => {
-    if (!form.checkValidity()) {
-      form.reportValidity();
-
-      return false;
-    }
-
-    return true;
+  isFormValid: (requiredFields, context) => {
+    return !!requiredFields.find(field => !context[field] || !context[field].value);
   },
 };
 


### PR DESCRIPTION
This moves the disabling of the submit button from being in the FormWrap to being a prop so that each FormWrap can be controlled instead of expecting the component to know how we're validating fields.

This also updates the styling a little bit for the Field validation notice 
<img width="1101" alt="Screen Shot 2019-07-25 at 2 57 49 PM" src="https://user-images.githubusercontent.com/122591/61904800-30293580-aeed-11e9-80ad-2809d3a8da07.png">

Lastly, it moves the form's title and description to props on FormWrap, named `title` and `description` respectively. This way the layout will stay consistent as we begin integrating error messages that will be output to the UI.

This PR is a precursor to getting #146 ready to merge in as this will be creating the rendered errors.