### PR TITLE
Record when users agree to auto-setup

### DIFF
--- a/src/main/java/org/graylog/integrations/aws/resources/KinesisSetupResource.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/KinesisSetupResource.java
@@ -17,7 +17,6 @@ import org.graylog.integrations.aws.service.CloudWatchService;
 import org.graylog.integrations.aws.service.KinesisService;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.rest.PluginRestResource;
-import org.graylog2.rest.resources.system.inputs.AbstractInputsResource;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,7 +71,7 @@ public class KinesisSetupResource extends RestResource implements PluginRestReso
         LOG.info("User [{}] agreed to the Kinesis auto-setup, which will create a Kinesis stream [{}], " +
                  "role/policy, and a CloudWatch log group Subscription. " +
                  "This has been recorded, since AWS resources that will cost money are being created " +
-                 "at the sole request of this user.", user.getId(), request.streamName() );
+                 "at the sole request of this user.", user.getId(), request.streamName());
 
         LOG.info("Stream request: [{}]", request);
         if (mockResponses) {

--- a/src/main/java/org/graylog/integrations/aws/resources/KinesisSetupResource.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/KinesisSetupResource.java
@@ -15,7 +15,10 @@ import org.graylog.integrations.aws.resources.responses.CreateRolePermissionResp
 import org.graylog.integrations.aws.resources.responses.KinesisNewStreamResponse;
 import org.graylog.integrations.aws.service.CloudWatchService;
 import org.graylog.integrations.aws.service.KinesisService;
+import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.rest.PluginRestResource;
+import org.graylog2.rest.resources.system.inputs.AbstractInputsResource;
+import org.graylog2.shared.rest.resources.RestResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +39,7 @@ import javax.ws.rs.core.MediaType;
 @RequiresAuthentication
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class KinesisSetupResource implements PluginRestResource {
+public class KinesisSetupResource extends RestResource implements PluginRestResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(KinesisSetupResource.class);
     private static final int REQUEST_DELAY = 2000;
@@ -61,6 +64,15 @@ public class KinesisSetupResource implements PluginRestResource {
     @RequiresPermissions(AWSPermissions.AWS_READ)
     public KinesisNewStreamResponse createNewKinesisStream(@ApiParam(name = "JSON body", required = true) @Valid @NotNull
                                                                    KinesisNewStreamRequest request) throws InterruptedException {
+
+        // Record the fact that a particular user agreed to create AWS resources.
+        // Print the user id (instead of name) in the log. This is harder to trace back, but it avoids recording actual
+        // user names in the server log file.
+        final User user = getCurrentUser();
+        LOG.info("User [{}] agreed to the Kinesis auto-setup, which will create a Kinesis stream [{}], " +
+                 "role/policy, and a CloudWatch log group Subscription. " +
+                 "This has been recorded, since AWS resources that will cost money are being created " +
+                 "at the sole request of this user.", user.getId(), request.streamName() );
 
         LOG.info("Stream request: [{}]", request);
         if (mockResponses) {


### PR DESCRIPTION
Creates a record of when users agree to create AWS resources through the AWS Kinesis auto-setup flow. 

Since AWS resources cost money, we are explicitly recording when a particular user agrees to create resources though the Kinesis auto-setup flow.

Only the user id is logged (instead of the full user name) to avoid leaking user names/full names out into the server log file.

The resulting message looks like this (note that the local admin user name is logged since it does not actually exist in the database):
>  User [local:admin] agreed to the Kinesis auto-setup, which will create a Kinesis stream [test], role/policy, and a CloudWatch log group Subscription. This has been recorded, since AWS resources that will cost money are being created at the sole request of this user.
