### PR TITLE
Adding Permissions component to StepAuthorize

### DIFF
--- a/src/web/aws-cloudwatch/StepAuthorize.jsx
+++ b/src/web/aws-cloudwatch/StepAuthorize.jsx
@@ -4,10 +4,12 @@ import styled from 'styled-components';
 
 import { FormDataContext } from './context/FormData';
 import { ApiContext } from './context/Api';
+import { SidebarContext } from './context/Sidebar';
 
 import ValidatedInput from '../common/ValidatedInput';
 import MaskedInput from '../common/MaskedInput';
 import FormWrap from '../common/FormWrap';
+import Permissions from '../common/Permissions';
 import { renderOptions } from '../common/Options';
 import { ApiRoutes } from '../common/Routes';
 import useFetch from '../common/hooks/useFetch';
@@ -16,6 +18,7 @@ import formValidation from '../utils/formValidation';
 
 const StepAuthorize = ({ onChange, onSubmit }) => {
   const { formData } = useContext(FormDataContext);
+  const { setSidebar } = useContext(SidebarContext);
   const { availableRegions, setRegions, setStreams } = useContext(ApiContext);
   const [formError, setFormError] = useState(null);
   const [fetchRegionsStatus] = useFetch(ApiRoutes.INTEGRATIONS.AWS.REGIONS, setRegions, 'GET');
@@ -58,6 +61,10 @@ const StepAuthorize = ({ onChange, onSubmit }) => {
   const handleSubmit = () => {
     setStreamsFetch(ApiRoutes.INTEGRATIONS.AWS.KINESIS.STREAMS);
   };
+
+  useEffect(() => {
+    setSidebar(<Permissions />);
+  }, []);
 
   return (
     <>

--- a/src/web/aws-cloudwatch/StepAuthorize.jsx
+++ b/src/web/aws-cloudwatch/StepAuthorize.jsx
@@ -18,7 +18,7 @@ import formValidation from '../utils/formValidation';
 
 const StepAuthorize = ({ onChange, onSubmit }) => {
   const { formData } = useContext(FormDataContext);
-  const { setSidebar } = useContext(SidebarContext);
+  const { clearSidebar, setSidebar } = useContext(SidebarContext);
   const { availableRegions, setRegions, setStreams } = useContext(ApiContext);
   const [formError, setFormError] = useState(null);
   const [fetchRegionsStatus] = useFetch(ApiRoutes.INTEGRATIONS.AWS.REGIONS, setRegions, 'GET');
@@ -64,6 +64,10 @@ const StepAuthorize = ({ onChange, onSubmit }) => {
 
   useEffect(() => {
     setSidebar(<Permissions />);
+
+    return () => {
+      clearSidebar();
+    };
   }, []);
 
   return (

--- a/src/web/common/Permissions.jsx
+++ b/src/web/common/Permissions.jsx
@@ -1,0 +1,99 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Panel } from 'react-bootstrap';
+
+const DEMODATA = {
+  Version: '2012-10-17',
+  Statement: [
+    {
+      Sid: 'statement1',
+      Effect: 'Allow',
+      Action: [
+        's3:CreateBucket',
+        's3:ListAllMyBuckets',
+        's3:GetBucketLocation',
+      ],
+      Resource: [
+        'arn:aws:s3:::*',
+      ],
+    },
+  ],
+};
+
+function Policies({ title, note, policy }) {
+  const [opened, setOpened] = useState(false);
+  const toggleOpen = () => {
+    setOpened(!opened);
+  };
+
+  return (
+    <div>
+      <Header onClick={toggleOpen}>
+        <HeaderContent>
+          <Title>{opened ? 'Hide' : 'Show'} {title}</Title>
+          <Note>{note}</Note>
+        </HeaderContent>
+
+        <Icon opened={opened}><i className="fa fa-chevron-right fa-2x" /></Icon>
+      </Header>
+
+      <Policy opened={opened}>
+        {JSON.stringify(policy, null, 2)}
+      </Policy>
+    </div>
+  );
+}
+
+Policies.propTypes = {
+  title: PropTypes.string.isRequired,
+  note: PropTypes.string.isRequired,
+  policy: PropTypes.object.isRequired,
+};
+
+export default function Permissions() {
+  return (
+    <Panel bsStyle="info" header={<span>AWS Policy Permissions</span>}>
+      <p>Lorem ipsum dolor sit amet consectetur, adipisicing elit. Ipsa debitis, voluptatum id illo excepturi, magni recusandae accusamus veritatis repellendus nam voluptas nihil ad dolorum dolores cum laboriosam minima cupiditate necessitatibus.</p>
+
+      <Policies title="Recommended Policy"
+                note="To be able to use all available functionality for Kinesis setup."
+                policy={DEMODATA} />
+
+      <Policies title="Least Privilege Policy"
+                note="Doesn&apos;t include Kinesis auto-subscribtion controls."
+                policy={DEMODATA} />
+    </Panel>
+  );
+}
+
+const Header = styled.header`
+  display: flex;
+  align-items: center;
+`;
+
+const HeaderContent = styled.div`
+  flex-grow: 1;
+`;
+
+const Icon = styled.span`
+  transform: rotate(${props => (props.opened ? '90deg' : '0deg')});
+  transition: transform 150ms ease-in-out;
+`;
+
+const Policy = styled.pre`
+  overflow: hidden;
+  max-height: ${props => (props.opened ? '1000px' : '0')};
+  opacity: ${props => (props.opened ? '1' : '0')};
+  transition: max-height 150ms ease-in-out, opacity 150ms ease-in-out, margin 150ms ease-in-out, padding 150ms ease-in-out;
+  margin-bottom: ${props => (props.opened ? '12px' : '0')};
+  padding: ${props => (props.opened ? '9.5px' : '0')};
+`;
+
+const Title = styled.h4`
+  font-weight: bold;
+`;
+
+const Note = styled.p`
+  font-style: italic;
+`;


### PR DESCRIPTION
UI to inform the users of the expected policy permissions they will need to setup manually in their AWS account.

Could maybe use some intro text in place of the Lorem Ipsum

![image](https://user-images.githubusercontent.com/122591/63054729-0e96ea80-beaa-11e9-93d6-55b59be60d47.png)
![image](https://user-images.githubusercontent.com/122591/63054755-1a82ac80-beaa-11e9-9fe6-124904f824f5.png)
