### PR TITLE
Add Audit Log entries for AWS Kinesis/CloudWatch

### DIFF
--- a/src/main/java/org/graylog/integrations/IntegrationsModule.java
+++ b/src/main/java/org/graylog/integrations/IntegrationsModule.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.integrations;
 
+import org.graylog.integrations.audit.IntegrationsAuditEventTypes;
 import org.graylog.integrations.aws.AWSPermissions;
 import org.graylog.integrations.aws.codecs.AWSCodec;
 import org.graylog.integrations.aws.codecs.KinesisCloudWatchFlowLogCodec;
@@ -78,6 +79,8 @@ public class IntegrationsModule extends PluginModule {
          *
          * addConfigBeans();
          */
+
+        addAuditEventTypes(IntegrationsAuditEventTypes.class);
 
         // Palo Alto Networks
         LOG.debug("Registering message input: {}", PaloAltoTCPInput.NAME);

--- a/src/main/java/org/graylog/integrations/audit/IntegrationsAuditEventTypes.java
+++ b/src/main/java/org/graylog/integrations/audit/IntegrationsAuditEventTypes.java
@@ -1,0 +1,44 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.integrations.audit;
+
+import com.google.common.collect.ImmutableSet;
+import org.graylog2.audit.PluginAuditEventTypes;
+
+import java.util.Set;
+
+public class IntegrationsAuditEventTypes implements PluginAuditEventTypes {
+    private static final String NAMESPACE = "integrations:";
+
+    public static final String KINESIS_INPUT_CREATE = NAMESPACE + "kinesis_input:create";
+
+    public static final String KINESIS_SETUP_CREATE_STREAM = NAMESPACE + "kinesis_auto_setup:create_stream";
+    public static final String KINESIS_SETUP_CREATE_POLICY = NAMESPACE + "kinesis_auto_setup:create_policy";
+    public static final String KINESIS_SETUP_CREATE_SUBSCRIPTION = NAMESPACE + "kinesis_auto_setup:create_subscription";
+
+
+    private static final Set<String> EVENT_TYPES = ImmutableSet.<String>builder()
+            .add(KINESIS_SETUP_CREATE_STREAM)
+            .add(KINESIS_SETUP_CREATE_POLICY)
+            .add(KINESIS_SETUP_CREATE_SUBSCRIPTION)
+            .build();
+
+    @Override
+    public Set<String> auditEventTypes() {
+        return EVENT_TYPES;
+    }
+}

--- a/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/AWSResource.java
@@ -8,6 +8,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.graylog.integrations.audit.IntegrationsAuditEventTypes;
 import org.graylog.integrations.aws.AWSPermissions;
 import org.graylog.integrations.aws.resources.requests.AWSInputCreateRequest;
 import org.graylog.integrations.aws.resources.requests.AWSRequestImpl;
@@ -21,8 +22,8 @@ import org.graylog.integrations.aws.resources.responses.StreamsResponse;
 import org.graylog.integrations.aws.service.AWSService;
 import org.graylog.integrations.aws.service.CloudWatchService;
 import org.graylog.integrations.aws.service.KinesisService;
-import org.graylog2.audit.AuditEventTypes;
 import org.graylog2.audit.jersey.AuditEvent;
+import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.inputs.Input;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.rest.resources.system.inputs.AbstractInputsResource;
@@ -107,6 +108,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
     @Path("/cloudwatch/log_groups")
     @ApiOperation(value = "Get all available AWS CloudWatch log groups names for the specified region.")
     @RequiresPermissions(AWSPermissions.AWS_READ)
+    @NoAuditEvent("This does not change any data")
     public LogGroupsResponse getLogGroupNames(@ApiParam(name = "JSON body", required = true) @Valid @NotNull AWSRequestImpl awsRequest) {
         return cloudWatchService.getLogGroupNames(awsRequest.region(), awsRequest.awsAccessKeyId(), awsRequest.awsSecretAccessKey());
     }
@@ -119,6 +121,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
     @Path("/kinesis/streams")
     @ApiOperation(value = "Get all available Kinesis streams for the specified region.")
     @RequiresPermissions(AWSPermissions.AWS_READ)
+    @NoAuditEvent("This does not change any data")
     public StreamsResponse getKinesisStreams(@ApiParam(name = "JSON body", required = true) @Valid @NotNull AWSRequestImpl awsRequest) throws ExecutionException {
         return kinesisService.getKinesisStreamNames(awsRequest.region(), awsRequest.awsAccessKeyId(), awsRequest.awsSecretAccessKey());
     }
@@ -134,6 +137,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
             response = KinesisHealthCheckResponse.class
     )
     @RequiresPermissions(AWSPermissions.AWS_READ)
+    @NoAuditEvent("This does not change any data")
     public Response kinesisHealthCheck(@ApiParam(name = "JSON body", required = true) @Valid @NotNull KinesisHealthCheckRequest heathCheckRequest) throws ExecutionException, IOException {
 
         KinesisHealthCheckResponse response = kinesisService.healthCheck(heathCheckRequest);
@@ -148,7 +152,7 @@ public class AWSResource extends AbstractInputsResource implements PluginRestRes
     @Path("/inputs")
     @ApiOperation(value = "Create a new AWS input.")
     @RequiresPermissions(RestPermissions.INPUTS_CREATE)
-    @AuditEvent(type = AuditEventTypes.MESSAGE_INPUT_CREATE)
+    @AuditEvent(type = IntegrationsAuditEventTypes.KINESIS_INPUT_CREATE)
     public Response create(@ApiParam(name = "JSON body", required = true)
                            @Valid @NotNull AWSInputCreateRequest saveRequest) throws Exception {
 

--- a/src/main/java/org/graylog/integrations/aws/resources/KinesisSetupResource.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/KinesisSetupResource.java
@@ -50,7 +50,7 @@ public class KinesisSetupResource extends RestResource implements PluginRestReso
 
     // Enable mocked responses for UI testing.
     // TODO: Remove later.
-    public boolean mockResponses = false;
+    public boolean mockResponses = true;
 
     @Inject
     public KinesisSetupResource(CloudWatchService cloudWatchService, KinesisService kinesisService) {

--- a/src/main/java/org/graylog/integrations/aws/resources/responses/CreateRolePermissionResponse.java
+++ b/src/main/java/org/graylog/integrations/aws/resources/responses/CreateRolePermissionResponse.java
@@ -11,6 +11,7 @@ import org.graylog.autovalue.WithBeanGetter;
 public abstract class CreateRolePermissionResponse {
     private static final String RESULT = "result";
     private static final String ROLE_ARN = "role_arn";
+    private static final String ROLE_NAME = "role_name";
 
     @JsonProperty(RESULT)
     public abstract String result();
@@ -18,8 +19,12 @@ public abstract class CreateRolePermissionResponse {
     @JsonProperty(ROLE_ARN)
     public abstract String roleArn();
 
+    @JsonProperty(ROLE_NAME)
+    public abstract String roleName();
+
     public static CreateRolePermissionResponse create(@JsonProperty(RESULT) String result,
-                                                      @JsonProperty(ROLE_ARN) String roleArn) {
-        return new AutoValue_CreateRolePermissionResponse(result, roleArn);
+                                                      @JsonProperty(ROLE_ARN) String roleArn,
+                                                      @JsonProperty(ROLE_NAME) String roleName) {
+        return new AutoValue_CreateRolePermissionResponse(result, roleArn, roleName);
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/service/KinesisService.java
+++ b/src/main/java/org/graylog/integrations/aws/service/KinesisService.java
@@ -496,7 +496,7 @@ public class KinesisService {
 
             final String roleArn = getRolePermissionsArn(iamClient, roleName);
             final String explanation = String.format("Success! The role [%s/%s] has been created.", roleName, roleArn);
-            return CreateRolePermissionResponse.create(explanation, roleArn);
+            return CreateRolePermissionResponse.create(explanation, roleArn, roleName);
 
         } catch (Exception e) {
             final String specificError = ExceptionUtils.formatMessageCause(e);


### PR DESCRIPTION
## Overview 
Add Enterprise Audit Log entries for the following AWS actions:

* Create a new AWS input through the new AWS setup flow.
* Performing the automated Kinesis setup, which includes: Kinesis stream creation, IAM role creation, and CloudWatch -> Kinesis subscription creation.

## Motivation and Context
These actions both create resources in the customer's AWS and Graylog environments, so I think we want to create Audit Log entries for them.

See https://github.com/Graylog2/graylog-plugin-enterprise/pull/1199 for the respective Audit Log formats.