### PR TITLE
Rename AWS input > "AWS Kinesis/CloudWatch"

### DIFF
--- a/src/main/java/org/graylog/integrations/aws/inputs/AWSInput.java
+++ b/src/main/java/org/graylog/integrations/aws/inputs/AWSInput.java
@@ -44,7 +44,7 @@ import javax.inject.Inject;
  */
 public class AWSInput extends MessageInput {
 
-    public static final String NAME = "AWS";
+    public static final String NAME = "AWS Kinesis/CloudWatch";
     public static final String TYPE = "org.graylog.integrations.aws.inputs.AWSInput";
 
     public static final String CK_TITLE = "title";


### PR DESCRIPTION
Rename "AWS" input to "AWS Kinesis/CloudWatch"

This is because we do not have a Choose Service page right now. This name will be changed in the future when additional services and a Choose Service page is added.