### PR TITLE
Set correct scope for Kinesis SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
             <groupId>software.amazon.kinesis</groupId>
             <artifactId>amazon-kinesis-client</artifactId>
             <version>${aws-kinesis-client.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- Include the latest version of the Apache Http Client as required by the AWS SDK v2 -->


### PR DESCRIPTION
The scope for the Kinesis SDK dependency should not be 'provided'