### PR TITLE
Use bundled/shaded AWS SDK dependency to avoid dependency conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
             <version>1.7</version>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.graylog2</groupId>
             <artifactId>graylog2-server</artifactId>
             <version>${graylog.version}</version>


### PR DESCRIPTION
This resolves the improper Apache httpclient and Netty version conflicts.