### PR TITLE
Drats! exclamation-triangle instead of times

### DIFF
--- a/src/web/aws-cloudwatch/StepHealthCheck.jsx
+++ b/src/web/aws-cloudwatch/StepHealthCheck.jsx
@@ -83,7 +83,7 @@ const StepHealthCheck = ({ onChange, onSubmit }) => {
   }
 
   const unknownLog = logData.type === DEFAULT_KINESIS_LOG_TYPE;
-  const iconClass = unknownLog ? 'times' : 'check';
+  const iconClass = unknownLog ? 'exclamation-triangle' : 'check';
   const acknowledgment = unknownLog ? 'Drats!' : 'Awesome!';
   const bsStyle = unknownLog ? 'warning' : 'success';
   const logType = unknownLog ? 'an unknown' : 'a Flow Log';


### PR DESCRIPTION
Replace the `times` icon with the `exclamation-triangle` icon on the Health Check page when an unknown log type is found.