### PR TITLE
Tweaks to documentation links

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -3,7 +3,7 @@ Getting started with your new Graylog plugin
 
 Welcome to your new Graylog plugin!
 
-Please refer to http://docs.graylog.org/en/latest/pages/plugins.html for documentation on how to write
+Please refer to https://docs.graylog.org/en/latest/pages/plugins.html for documentation on how to write
 plugins for Graylog.
 
 Travis CI

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Overview
 Integrations are tools that help Graylog work with external systems. This plugin contains all open source integrations
 features.
 
-Please refer to the [documentation](http://docs.graylog.org/en/3.0/pages/integrations.html) for additional details 
-and setup instructions.     
+Please refer to the [documentation](https://docs.graylog.org/en/latest/pages/integrations.html) for additional details
+and setup instructions.


### PR DESCRIPTION
Prefer HTTPS over HTTP and link to the latest available documentation.