### PR TITLE
Fix reversed AWS Message Type labels

### DIFF
--- a/src/main/java/org/graylog/integrations/aws/AWSMessageType.java
+++ b/src/main/java/org/graylog/integrations/aws/AWSMessageType.java
@@ -24,11 +24,11 @@ public enum AWSMessageType {
     KINESIS_RAW(Source.KINESIS, "Kinesis Raw", KinesisRawLogCodec.NAME,
                 KinesisRawLogCodec.Factory.class, KinesisTransport.NAME, KinesisTransport.Factory.class),
 
-    KINESIS_CLOUDWATCH_RAW(Source.KINESIS, "Kinesis CloudWatch Flow Log", KinesisRawLogCodec.NAME,
+    KINESIS_CLOUDWATCH_RAW(Source.KINESIS, "Kinesis CloudWatch Raw", KinesisRawLogCodec.NAME,
                            KinesisRawLogCodec.Factory.class, KinesisTransport.NAME, KinesisTransport.Factory.class),
 
     // Flow Logs delivered to Kinesis via CloudWatch subscriptions.
-    KINESIS_CLOUDWATCH_FLOW_LOGS(Source.KINESIS, "Kinesis CloudWatch Raw", KinesisCloudWatchFlowLogCodec.NAME,
+    KINESIS_CLOUDWATCH_FLOW_LOGS(Source.KINESIS, "Kinesis CloudWatch Flow Log", KinesisCloudWatchFlowLogCodec.NAME,
                                  KinesisCloudWatchFlowLogCodec.Factory.class, KinesisTransport.NAME, KinesisTransport.Factory.class),
 
     UNKNOWN();


### PR DESCRIPTION
The enum labels for Kinesis CloudWatch Raw and Kinesis CloudWatch Flow Log were reversed. This has been fixed.

Backported to `3.1` branch in #262