### PR TITLE
Add missing audit registration

### DIFF
--- a/src/main/java/org/graylog/integrations/audit/IntegrationsAuditEventTypes.java
+++ b/src/main/java/org/graylog/integrations/audit/IntegrationsAuditEventTypes.java
@@ -32,6 +32,7 @@ public class IntegrationsAuditEventTypes implements PluginAuditEventTypes {
 
 
     private static final Set<String> EVENT_TYPES = ImmutableSet.<String>builder()
+            .add(KINESIS_INPUT_CREATE)
             .add(KINESIS_SETUP_CREATE_STREAM)
             .add(KINESIS_SETUP_CREATE_POLICY)
             .add(KINESIS_SETUP_CREATE_SUBSCRIPTION)


### PR DESCRIPTION
Fix #297 by adding missing audit log registration. 

I tested and confirmed that the error indicated in the issue is no longer occurring at server startup and that the specific audit log entry is generating.

![image](https://user-images.githubusercontent.com/3423655/67096984-d5674900-f17e-11e9-94cc-7a63881dec27.png)
