### PR TITLE
Retry when rate limit exception occurs for getStreams

### DIFF
--- a/src/main/java/org/graylog/integrations/aws/service/KinesisService.java
+++ b/src/main/java/org/graylog/integrations/aws/service/KinesisService.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.services.kinesis.model.CreateStreamRequest;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
+import software.amazon.awssdk.services.kinesis.model.LimitExceededException;
 import software.amazon.awssdk.services.kinesis.model.ListShardsRequest;
 import software.amazon.awssdk.services.kinesis.model.ListShardsResponse;
 import software.amazon.awssdk.services.kinesis.model.ListStreamsRequest;
@@ -71,7 +72,7 @@ public class KinesisService {
 
     private static final int EIGHT_BITS = 8;
     private static final int KINESIS_LIST_STREAMS_MAX_ATTEMPTS = 1000;
-    private static final int KINESIS_LIST_STREAMS_LIMIT = 30;
+    private static final int KINESIS_LIST_STREAMS_LIMIT = 400;
     private static final int RECORDS_SAMPLE_SIZE = 10;
     private static final int SHARD_COUNT = 1;
     private static final String ROLE_NAME_FORMAT = "graylog-cloudwatch-role-%s";
@@ -188,12 +189,14 @@ public class KinesisService {
         // Create retryer to keep checking if more streams exist.
         final Retryer<Boolean> retryer = RetryerBuilder.<Boolean>newBuilder()
                 .retryIfResult(b -> Objects.equals(b, Boolean.TRUE))
+                .retryIfExceptionOfType(LimitExceededException.class)
                 .withStopStrategy(StopStrategies.stopAfterAttempt(KINESIS_LIST_STREAMS_MAX_ATTEMPTS))
                 .build();
 
         if (listStreamsResponse.hasMoreStreams()) {
             try {
                 retryer.call(() -> {
+                    LOG.debug("Requesting streams...");
                     final String lastStreamName = streamNames.get(streamNames.size() - 1);
                     final ListStreamsRequest moreStreamsRequest = ListStreamsRequest.builder()
                                                                                     .exclusiveStartStreamName(lastStreamName)


### PR DESCRIPTION
Fixes #341 

* Retries if Kinesis `LimitExceededException` occurs.
* Increases page size for streams from 30 to 400 to reduce the need for successive calls. Retrying successive requests will only be needed for extremely large numbers of streams.

**Ref :** 
    https://docs.aws.amazon.com/streams/latest/dev/fundamental-stream.html
    https://docs.amazonaws.cn/en_us/kinesis/latest/APIReference/kinesis-api.pdf
    https://docs.aws.amazon.com/cli/latest/reference/kinesis/create-stream.html

**CLI Reference Guide:**
https://docs.aws.amazon.com/cli/latest/reference/kinesis/describe-limits.html

**CLI-Example  for AWS services IAM(Dynamodb|Cloud Watch|Kinesis...):**
````
helium@helium-Precision-5540:~/workspace/config/shell$ aws iam get-user
{
    "User": {
        "UserName": "xxxx", 
        "PasswordLastUsed": "2019-12-12T17:00:43Z", 
        "CreateDate": "2019-11-06T14:01:44Z", 
        "UserId": "AIDAWV25I6RLUN4BMLKXB", 
        "Path": "/", 
        "Arn": "arn:aws:iam::459220251735:user/xxx"
    }
}
```
