### PR TITLE
Correctly return an unresolved authentication provider

### DIFF
--- a/src/main/java/org/graylog/integrations/aws/AWSAuthFactory.java
+++ b/src/main/java/org/graylog/integrations/aws/AWSAuthFactory.java
@@ -31,9 +31,9 @@ public class AWSAuthFactory {
      * Javadoc for more information.
      */
     public static AwsCredentialsProvider getAuthProvider(@Nullable String accessKey,
-                                                  @Nullable String secretKey,
-                                                  @Nullable String stsRegion,
-                                                  @Nullable String assumeRoleArn) {
+                                                         @Nullable String secretKey,
+                                                         @Nullable String stsRegion,
+                                                         @Nullable String assumeRoleArn) {
         AwsCredentialsProvider awsCredentials;
         if (!isNullOrEmpty(accessKey) && !isNullOrEmpty(secretKey)) {
             LOG.debug("Using explicitly provided key and secret.");
@@ -59,7 +59,7 @@ public class AWSAuthFactory {
      * permission, which provides authorization for a role to be assumed.
      */
     private static AwsCredentialsProvider buildStsCredentialsProvider(AwsCredentialsProvider awsCredentials, String stsRegion,
-                                                               String assumeRoleArn, @Nullable String accessKey) {
+                                                                      String assumeRoleArn, @Nullable String accessKey) {
 
         StsClient stsClient = StsClient.builder().region(Region.of(stsRegion)).credentialsProvider(awsCredentials).build();
 

--- a/src/main/java/org/graylog/integrations/aws/AWSAuthFactory.java
+++ b/src/main/java/org/graylog/integrations/aws/AWSAuthFactory.java
@@ -3,7 +3,6 @@ package org.graylog.integrations.aws;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -17,27 +16,24 @@ import javax.annotation.Nullable;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
-/**
- * Resolves the appropriate AWS authorization provider.
- *
- * If an {@code accessKey} and {@code secretKey} are provided, they will be used explicitly.
- * If not, the default DefaultCredentialsProvider will be used instead. This will resolve the role/policy
- * using Java props, environment variables, EC2 instance roles etc. See the {@link DefaultCredentialsProvider}
- * Javadoc for more information.
- */
-public class AWSAuthProvider implements AwsCredentialsProvider {
-    private static final Logger LOG = LoggerFactory.getLogger(AWSAuthProvider.class);
+public class AWSAuthFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(AWSAuthFactory.class);
 
-    private AwsCredentials credentials;
-
-    public AWSAuthProvider(@Nullable String stsRegion, @Nullable String accessKey, @Nullable String secretKey, @Nullable String assumeRoleArn) {
-        this.credentials = this.resolveAuthentication(accessKey, secretKey, stsRegion, assumeRoleArn);
+    private AWSAuthFactory() {
     }
 
-    private AwsCredentials resolveAuthentication(@Nullable String accessKey,
-                                                 @Nullable String secretKey,
-                                                 @Nullable String stsRegion,
-                                                 @Nullable String assumeRoleArn) {
+    /**
+     * Resolves the appropriate AWS authorization provider based on the input.
+     *
+     * If an {@code accessKey} and {@code secretKey} are provided, they will be used explicitly.
+     * If not, the default DefaultCredentialsProvider will be used instead. This will resolve the role/policy
+     * using Java props, environment variables, EC2 instance roles etc. See the {@link DefaultCredentialsProvider}
+     * Javadoc for more information.
+     */
+    public static AwsCredentialsProvider getAuthProvider(@Nullable String accessKey,
+                                                  @Nullable String secretKey,
+                                                  @Nullable String stsRegion,
+                                                  @Nullable String assumeRoleArn) {
         AwsCredentialsProvider awsCredentials;
         if (!isNullOrEmpty(accessKey) && !isNullOrEmpty(secretKey)) {
             LOG.debug("Using explicitly provided key and secret.");
@@ -50,11 +46,10 @@ public class AWSAuthProvider implements AwsCredentialsProvider {
         // Apply the Assume Role ARN Authorization if specified. All AWSCredentialsProviders support this.
         if (!isNullOrEmpty(assumeRoleArn) && !isNullOrEmpty(stsRegion)) {
             LOG.debug("Creating cross account assume role credentials");
-            return buildStsCredentialsProvider(awsCredentials, stsRegion, assumeRoleArn, accessKey)
-                    .resolveCredentials();
+            return buildStsCredentialsProvider(awsCredentials, stsRegion, assumeRoleArn, accessKey);
         }
 
-        return awsCredentials.resolveCredentials();
+        return awsCredentials;
     }
 
     /**
@@ -63,7 +58,7 @@ public class AWSAuthProvider implements AwsCredentialsProvider {
      * Note: In order to assume a role, a role must be provided to the AWS STS client a role that has the "sts:AssumeRole"
      * permission, which provides authorization for a role to be assumed.
      */
-    private AwsCredentialsProvider buildStsCredentialsProvider(AwsCredentialsProvider awsCredentials, String stsRegion,
+    private static AwsCredentialsProvider buildStsCredentialsProvider(AwsCredentialsProvider awsCredentials, String stsRegion,
                                                                String assumeRoleArn, @Nullable String accessKey) {
 
         StsClient stsClient = StsClient.builder().region(Region.of(stsRegion)).credentialsProvider(awsCredentials).build();
@@ -86,10 +81,5 @@ public class AWSAuthProvider implements AwsCredentialsProvider {
                                                                                           .build())
                                                .stsClient(stsClient)
                                                .build();
-    }
-
-    @Override
-    public AwsCredentials resolveCredentials() {
-        return credentials;
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/AWSAuthFactory.java
+++ b/src/main/java/org/graylog/integrations/aws/AWSAuthFactory.java
@@ -19,9 +19,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 public class AWSAuthFactory {
     private static final Logger LOG = LoggerFactory.getLogger(AWSAuthFactory.class);
 
-    private AWSAuthFactory() {
-    }
-
     /**
      * Resolves the appropriate AWS authorization provider based on the input.
      *
@@ -30,10 +27,10 @@ public class AWSAuthFactory {
      * using Java props, environment variables, EC2 instance roles etc. See the {@link DefaultCredentialsProvider}
      * Javadoc for more information.
      */
-    public static AwsCredentialsProvider getAuthProvider(@Nullable String accessKey,
-                                                         @Nullable String secretKey,
-                                                         @Nullable String stsRegion,
-                                                         @Nullable String assumeRoleArn) {
+    public static AwsCredentialsProvider create(@Nullable String accessKey,
+                                                @Nullable String secretKey,
+                                                @Nullable String stsRegion,
+                                                @Nullable String assumeRoleArn) {
         AwsCredentialsProvider awsCredentials;
         if (!isNullOrEmpty(accessKey) && !isNullOrEmpty(secretKey)) {
             LOG.debug("Using explicitly provided key and secret.");

--- a/src/main/java/org/graylog/integrations/aws/AWSClientBuilderUtil.java
+++ b/src/main/java/org/graylog/integrations/aws/AWSClientBuilderUtil.java
@@ -56,8 +56,8 @@ public class AWSClientBuilderUtil {
         AWSClientBuilderUtil.initializeBuilder(clientBuilder,
                                                request.cloudwatchEndpoint(),
                                                Region.of(request.region()),
-                                               new AWSAuthProvider(request.region(), request.awsAccessKeyId(),
-                                                                   request.awsSecretAccessKey(), request.assumeRoleArn()));
+                                               AWSAuthFactory.getAuthProvider(request.region(), request.awsAccessKeyId(),
+                                                                  request.awsSecretAccessKey(), request.assumeRoleArn()));
 
         return clientBuilder.build();
     }
@@ -74,8 +74,8 @@ public class AWSClientBuilderUtil {
         AWSClientBuilderUtil.initializeBuilder(clientBuilder,
                                                request.kinesisEndpoint(),
                                                Region.of(request.region()),
-                                               new AWSAuthProvider(request.region(), request.awsAccessKeyId(),
-                                                                   request.awsSecretAccessKey(), request.assumeRoleArn()));
+                                               AWSAuthFactory.getAuthProvider(request.region(), request.awsAccessKeyId(),
+                                                                  request.awsSecretAccessKey(), request.assumeRoleArn()));
 
         return clientBuilder.build();
     }
@@ -92,9 +92,9 @@ public class AWSClientBuilderUtil {
         AWSClientBuilderUtil.initializeBuilder(clientBuilder,
                                                request.iamEndpoint(),
                                                Region.AWS_GLOBAL, // Always specify the global region for the IAM client.
-                                               new AWSAuthProvider(request.region(), // The AWSAuthProvider must still use the user-specified region, since a role might need to be assumed in that region.
-                                                                   request.awsAccessKeyId(),
-                                                                   request.awsSecretAccessKey(), request.assumeRoleArn()));
+                                               AWSAuthFactory.getAuthProvider(request.region(), // The AWSAuthProvider must still use the user-specified region, since a role might need to be assumed in that region.
+                                                                  request.awsAccessKeyId(),
+                                                                  request.awsSecretAccessKey(), request.assumeRoleArn()));
         return clientBuilder.build();
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/AWSClientBuilderUtil.java
+++ b/src/main/java/org/graylog/integrations/aws/AWSClientBuilderUtil.java
@@ -56,8 +56,8 @@ public class AWSClientBuilderUtil {
         AWSClientBuilderUtil.initializeBuilder(clientBuilder,
                                                request.cloudwatchEndpoint(),
                                                Region.of(request.region()),
-                                               AWSAuthFactory.getAuthProvider(request.region(), request.awsAccessKeyId(),
-                                                                  request.awsSecretAccessKey(), request.assumeRoleArn()));
+                                               AWSAuthFactory.create(request.region(), request.awsAccessKeyId(),
+                                                                     request.awsSecretAccessKey(), request.assumeRoleArn()));
 
         return clientBuilder.build();
     }
@@ -74,8 +74,8 @@ public class AWSClientBuilderUtil {
         AWSClientBuilderUtil.initializeBuilder(clientBuilder,
                                                request.kinesisEndpoint(),
                                                Region.of(request.region()),
-                                               AWSAuthFactory.getAuthProvider(request.region(), request.awsAccessKeyId(),
-                                                                  request.awsSecretAccessKey(), request.assumeRoleArn()));
+                                               AWSAuthFactory.create(request.region(), request.awsAccessKeyId(),
+                                                                     request.awsSecretAccessKey(), request.assumeRoleArn()));
 
         return clientBuilder.build();
     }
@@ -92,9 +92,9 @@ public class AWSClientBuilderUtil {
         AWSClientBuilderUtil.initializeBuilder(clientBuilder,
                                                request.iamEndpoint(),
                                                Region.AWS_GLOBAL, // Always specify the global region for the IAM client.
-                                               AWSAuthFactory.getAuthProvider(request.region(), // The AWSAuthProvider must still use the user-specified region, since a role might need to be assumed in that region.
-                                                                  request.awsAccessKeyId(),
-                                                                  request.awsSecretAccessKey(), request.assumeRoleArn()));
+                                               AWSAuthFactory.create(request.region(), // The AWSAuthProvider must still use the user-specified region, since a role might need to be assumed in that region.
+                                                                     request.awsAccessKeyId(),
+                                                                     request.awsSecretAccessKey(), request.assumeRoleArn()));
         return clientBuilder.build();
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/transports/KinesisConsumer.java
+++ b/src/main/java/org/graylog/integrations/aws/transports/KinesisConsumer.java
@@ -4,7 +4,7 @@ package org.graylog.integrations.aws.transports;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
-import org.graylog.integrations.aws.AWSAuthProvider;
+import org.graylog.integrations.aws.AWSAuthFactory;
 import org.graylog.integrations.aws.AWSClientBuilderUtil;
 import org.graylog.integrations.aws.AWSMessageType;
 import org.graylog.integrations.aws.resources.requests.AWSRequest;
@@ -76,8 +76,8 @@ public class KinesisConsumer implements Runnable {
     public void run() {
 
         LOG.debug("Starting the Kinesis Consumer.");
-        AwsCredentialsProvider credentialsProvider = new AWSAuthProvider(request.region(), request.awsAccessKeyId(),
-                                                                         request.awsSecretAccessKey(), request.assumeRoleArn());
+        AwsCredentialsProvider credentialsProvider = AWSAuthFactory.getAuthProvider(request.region(), request.awsAccessKeyId(),
+                                                                                    request.awsSecretAccessKey(), request.assumeRoleArn());
 
         final Region region = Region.of(request.region());
 

--- a/src/main/java/org/graylog/integrations/aws/transports/KinesisConsumer.java
+++ b/src/main/java/org/graylog/integrations/aws/transports/KinesisConsumer.java
@@ -76,8 +76,8 @@ public class KinesisConsumer implements Runnable {
     public void run() {
 
         LOG.debug("Starting the Kinesis Consumer.");
-        AwsCredentialsProvider credentialsProvider = AWSAuthFactory.getAuthProvider(request.region(), request.awsAccessKeyId(),
-                                                                                    request.awsSecretAccessKey(), request.assumeRoleArn());
+        AwsCredentialsProvider credentialsProvider = AWSAuthFactory.create(request.region(), request.awsAccessKeyId(),
+                                                                           request.awsSecretAccessKey(), request.assumeRoleArn());
 
         final Region region = Region.of(request.region());
 

--- a/src/test/java/org/graylog/integrations/aws/AWSAuthFactoryTest.java
+++ b/src/test/java/org/graylog/integrations/aws/AWSAuthFactoryTest.java
@@ -1,0 +1,21 @@
+package org.graylog.integrations.aws;
+
+import org.junit.Assert;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+
+public class AWSAuthFactoryTest {
+
+    @Test
+    public void testAutomaticAuth() {
+
+        Assert.assertTrue(AWSAuthFactory.create(null, null, null, null) instanceof DefaultCredentialsProvider);
+    }
+
+    @Test
+    public void testKeySecret() {
+
+        Assert.assertTrue(AWSAuthFactory.create("key", "secret", null, null) instanceof StaticCredentialsProvider);
+    }
+}


### PR DESCRIPTION
Correctly return an `AwsCredentialsProvider` without overriding or calling the `resolveAuthentication` method. This method should only be called internally within the AWS SDK. 

Previously, the Graylog `AWSAuthProvider` implementation  both manually called the `resolveAuthentication` method, an overrode it, which resulted in token refresh requests from [StsAssumeRoleCredentialsProvider](https://sdk.amazonaws.com/java/api/2.0.0-preview-11/software/amazon/awssdk/services/sts/auth/StsAssumeRoleCredentialsProvider.html) to be ignored.

Now, the implementation of [AWSAuthFactory](https://github.com/Graylog2/graylog-plugin-integrations/pull/389/files#diff-8521348d7b37ad0ba737860db3154682) simply creates and returns the `AwsCredentialsProvider`, which allows it to internally handle all credential resolution and refreshing correctly.

Fixes #386 