### PR TITLE
Backport: Correctly return an unresolved authentication provider (#389)

### DIFF
--- a/src/main/java/org/graylog/integrations/aws/AWSAuthFactory.java
+++ b/src/main/java/org/graylog/integrations/aws/AWSAuthFactory.java
@@ -27,9 +27,9 @@ public class AWSAuthFactory {
      * using Java props, environment variables, EC2 instance roles etc. See the {@link DefaultCredentialsProvider}
      * Javadoc for more information.
      */
-    public static AwsCredentialsProvider create(@Nullable String accessKey,
+    public static AwsCredentialsProvider create(@Nullable String stsRegion,
+                                                @Nullable String accessKey,
                                                 @Nullable String secretKey,
-                                                @Nullable String stsRegion,
                                                 @Nullable String assumeRoleArn) {
         AwsCredentialsProvider awsCredentials;
         if (!isNullOrEmpty(accessKey) && !isNullOrEmpty(secretKey)) {

--- a/src/main/java/org/graylog/integrations/aws/AWSClientBuilderUtil.java
+++ b/src/main/java/org/graylog/integrations/aws/AWSClientBuilderUtil.java
@@ -56,8 +56,8 @@ public class AWSClientBuilderUtil {
         AWSClientBuilderUtil.initializeBuilder(clientBuilder,
                                                request.cloudwatchEndpoint(),
                                                Region.of(request.region()),
-                                               new AWSAuthProvider(request.region(), request.awsAccessKeyId(),
-                                                                   request.awsSecretAccessKey(), request.assumeRoleArn()));
+                                               AWSAuthFactory.create(request.region(), request.awsAccessKeyId(),
+                                                                     request.awsSecretAccessKey(), request.assumeRoleArn()));
 
         return clientBuilder.build();
     }
@@ -74,8 +74,8 @@ public class AWSClientBuilderUtil {
         AWSClientBuilderUtil.initializeBuilder(clientBuilder,
                                                request.kinesisEndpoint(),
                                                Region.of(request.region()),
-                                               new AWSAuthProvider(request.region(), request.awsAccessKeyId(),
-                                                                   request.awsSecretAccessKey(), request.assumeRoleArn()));
+                                               AWSAuthFactory.create(request.region(), request.awsAccessKeyId(),
+                                                                     request.awsSecretAccessKey(), request.assumeRoleArn()));
 
         return clientBuilder.build();
     }
@@ -92,9 +92,9 @@ public class AWSClientBuilderUtil {
         AWSClientBuilderUtil.initializeBuilder(clientBuilder,
                                                request.iamEndpoint(),
                                                Region.AWS_GLOBAL, // Always specify the global region for the IAM client.
-                                               new AWSAuthProvider(request.region(), // The AWSAuthProvider must still use the user-specified region, since a role might need to be assumed in that region.
-                                                                   request.awsAccessKeyId(),
-                                                                   request.awsSecretAccessKey(), request.assumeRoleArn()));
+                                               AWSAuthFactory.create(request.region(), // The AWSAuthProvider must still use the user-specified region, since a role might need to be assumed in that region.
+                                                                     request.awsAccessKeyId(),
+                                                                     request.awsSecretAccessKey(), request.assumeRoleArn()));
         return clientBuilder.build();
     }
 }

--- a/src/main/java/org/graylog/integrations/aws/transports/KinesisConsumer.java
+++ b/src/main/java/org/graylog/integrations/aws/transports/KinesisConsumer.java
@@ -4,7 +4,7 @@ package org.graylog.integrations.aws.transports;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
-import org.graylog.integrations.aws.AWSAuthProvider;
+import org.graylog.integrations.aws.AWSAuthFactory;
 import org.graylog.integrations.aws.AWSClientBuilderUtil;
 import org.graylog.integrations.aws.AWSMessageType;
 import org.graylog.integrations.aws.resources.requests.AWSRequest;
@@ -76,8 +76,8 @@ public class KinesisConsumer implements Runnable {
     public void run() {
 
         LOG.debug("Starting the Kinesis Consumer.");
-        AwsCredentialsProvider credentialsProvider = new AWSAuthProvider(request.region(), request.awsAccessKeyId(),
-                                                                         request.awsSecretAccessKey(), request.assumeRoleArn());
+        AwsCredentialsProvider credentialsProvider = AWSAuthFactory.create(request.region(), request.awsAccessKeyId(),
+                                                                           request.awsSecretAccessKey(), request.assumeRoleArn());
 
         final Region region = Region.of(request.region());
 

--- a/src/test/java/org/graylog/integrations/aws/AWSAuthFactoryTest.java
+++ b/src/test/java/org/graylog/integrations/aws/AWSAuthFactoryTest.java
@@ -1,0 +1,21 @@
+package org.graylog.integrations.aws;
+
+import org.junit.Assert;
+import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+
+public class AWSAuthFactoryTest {
+
+    @Test
+    public void testAutomaticAuth() {
+
+        Assert.assertTrue(AWSAuthFactory.create(null, null, null, null) instanceof DefaultCredentialsProvider);
+    }
+
+    @Test
+    public void testKeySecret() {
+
+        Assert.assertTrue(AWSAuthFactory.create("key", "secret", null, null) instanceof StaticCredentialsProvider);
+    }
+}

--- a/src/test/java/org/graylog/integrations/aws/AWSAuthFactoryTest.java
+++ b/src/test/java/org/graylog/integrations/aws/AWSAuthFactoryTest.java
@@ -2,6 +2,7 @@ package org.graylog.integrations.aws;
 
 import org.junit.Assert;
 import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 
@@ -16,6 +17,9 @@ public class AWSAuthFactoryTest {
     @Test
     public void testKeySecret() {
 
-        Assert.assertTrue(AWSAuthFactory.create("key", "secret", null, null) instanceof StaticCredentialsProvider);
+        final AwsCredentialsProvider awsCredentialsProvider = AWSAuthFactory.create(null, "key", "secret", null);
+        Assert.assertTrue(awsCredentialsProvider instanceof StaticCredentialsProvider);
+        Assert.assertEquals("key", awsCredentialsProvider.resolveCredentials().accessKeyId());
+        Assert.assertEquals("secret", awsCredentialsProvider.resolveCredentials().secretAccessKey());
     }
 }


### PR DESCRIPTION
Backport of #389 and #392 

Cherry-picked commit 730302ddc2d3f3db2f2dd70910453ebceb85c115 3edaba46c911de86b0cc6f1fc06693821d66db18 and based this branch off of the latest `3.2` branch.