### PR TITLE
Fix incorrect `AWSAuthFactory.create` argument order

### DIFF
--- a/src/main/java/org/graylog/integrations/aws/AWSAuthFactory.java
+++ b/src/main/java/org/graylog/integrations/aws/AWSAuthFactory.java
@@ -27,9 +27,9 @@ public class AWSAuthFactory {
      * using Java props, environment variables, EC2 instance roles etc. See the {@link DefaultCredentialsProvider}
      * Javadoc for more information.
      */
-    public static AwsCredentialsProvider create(@Nullable String accessKey,
+    public static AwsCredentialsProvider create(@Nullable String stsRegion,
+                                                @Nullable String accessKey,
                                                 @Nullable String secretKey,
-                                                @Nullable String stsRegion,
                                                 @Nullable String assumeRoleArn) {
         AwsCredentialsProvider awsCredentials;
         if (!isNullOrEmpty(accessKey) && !isNullOrEmpty(secretKey)) {

--- a/src/test/java/org/graylog/integrations/aws/AWSAuthFactoryTest.java
+++ b/src/test/java/org/graylog/integrations/aws/AWSAuthFactoryTest.java
@@ -2,6 +2,7 @@ package org.graylog.integrations.aws;
 
 import org.junit.Assert;
 import org.junit.Test;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 
@@ -16,6 +17,9 @@ public class AWSAuthFactoryTest {
     @Test
     public void testKeySecret() {
 
-        Assert.assertTrue(AWSAuthFactory.create("key", "secret", null, null) instanceof StaticCredentialsProvider);
+        final AwsCredentialsProvider awsCredentialsProvider = AWSAuthFactory.create(null, "key", "secret", null);
+        Assert.assertTrue(awsCredentialsProvider instanceof StaticCredentialsProvider);
+        Assert.assertEquals("key", awsCredentialsProvider.resolveCredentials().accessKeyId());
+        Assert.assertEquals("secret", awsCredentialsProvider.resolveCredentials().secretAccessKey());
     }
 }


### PR DESCRIPTION
The argument order for `AWSAuthFactory.create` was wrong in #389, which causes key and secret authentication to fail. My test of this obviously was not correct, because this breaks key/secret auth :D Sorry about that. I added a basic unit test was added that would catch the argument transposition error in the future.

When reviewing, please check, the callers of `AWSAuthFactory.create` and make sure the argument order is correct.