### PR TITLE
Use protobuf version from parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,12 +121,6 @@
             <version>2.0.0</version>
         </dependency>
         <dependency>
-            <groupId>io.pkts</groupId>
-            <artifactId>pkts-core</artifactId>
-            <version>3.0.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>${protobuf.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:filter="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
@@ -34,7 +34,6 @@
         <graylog.version>3.3.0-SNAPSHOT</graylog.version>
         <aws-java-sdk-2.version>2.10.41</aws-java-sdk-2.version>
         <aws-kinesis-client.version>2.2.8</aws-kinesis-client.version>
-        <integrations.protobuf.version>3.11.1</integrations.protobuf.version>
     </properties>
 
     <dependencyManagement>
@@ -130,7 +129,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>${integrations.protobuf.version}</version>
+            <version>${protobuf.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Requires https://github.com/Graylog2/graylog2-server/pull/7962

Uses the protobuf version from the parent, thereby bumping it to version `3.11.4`.
I don't know how to properly smoke-test the Ipfix integrations.
It looks like at least some protobuf aspects are covered by the unit tests. These still pass with the new version but I'd appreciate if someone could do a "real" test.

Make sure to test with https://github.com/Graylog2/graylog2-server/pull/7962 checked out.