### PR TITLE
Add jenkins pipeline

### DIFF
--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -1,0 +1,3 @@
+@Library('ci-pipeline-shared') _
+
+buildSnapshot()


### PR DESCRIPTION
Add logic for a Jenkins pipeline. Merging this PR will enable the CI job on the new Jenkins instance at http://jenkins.ci.torch.sh.

I will leave the old Jenkins build enabled this week so builds can be compared between the two environments. Once we are sure the builds succeed or fail in the same way in both environments, I will disable the build in the old environment and complete migration.