### PR TITLE
Updates to fix AWS Input for GovCloud

### DIFF
--- a/src/main/java/org/graylog/integrations/aws/AWSClientBuilderUtil.java
+++ b/src/main/java/org/graylog/integrations/aws/AWSClientBuilderUtil.java
@@ -88,10 +88,14 @@ public class AWSClientBuilderUtil {
      * @return A fully built {@link IamClient}
      */
     public static IamClient buildClient(IamClientBuilder clientBuilder, AWSRequest request) {
+        Region iamRegion = Region.AWS_GLOBAL;
+        if (request.region().contains("gov")) {
+            iamRegion = Region.AWS_US_GOV_GLOBAL;
+        }
 
         AWSClientBuilderUtil.initializeBuilder(clientBuilder,
                                                request.iamEndpoint(),
-                                               Region.AWS_GLOBAL, // Always specify the global region for the IAM client.
+                                               iamRegion, // Always specify the appropriate global region for the IAM client.
                                                AWSAuthFactory.create(request.region(), // The AWSAuthProvider must still use the user-specified region, since a role might need to be assumed in that region.
                                                                      request.awsAccessKeyId(),
                                                                      request.awsSecretAccessKey(), request.assumeRoleArn()));

--- a/src/main/java/org/graylog/integrations/aws/service/AWSService.java
+++ b/src/main/java/org/graylog/integrations/aws/service/AWSService.java
@@ -186,6 +186,7 @@ public class AWSService {
                                              "elasticloadbalancing:DescribeLoadBalancers",
                                              "iam:CreateRole",
                                              "iam:GetRole",
+                                             "iam:PassRole",
                                              "iam:PutRolePolicy",
                                              "kinesis:CreateStream",
                                              "kinesis:DescribeStream",

--- a/src/test/java/org/graylog/integrations/aws/AwsClientBuilderUtilTest.java
+++ b/src/test/java/org/graylog/integrations/aws/AwsClientBuilderUtilTest.java
@@ -1,0 +1,158 @@
+package org.graylog.integrations.aws;
+
+import org.graylog.integrations.aws.resources.requests.AWSRequest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.IamClientBuilder;
+
+import java.net.URI;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AwsClientBuilderUtilTest {
+
+    // Mock Objects
+    @Mock private IamClientBuilder mockIamClientBuilder;
+    @Mock private AWSRequest mockAwsRequest;
+
+    // Test Objects
+    IamClient iamClient;
+
+    // Test Cases
+    @Test
+    public void buildClient_returnsNonGovIamClient_whenNonGovRegionNullEndpoint() {
+        givenNonGovAwsRegion();
+        givenGoodCredentialsProvider();
+        givenNullEndpoint();
+        givenBuilderSucceeds();
+
+        whenBuildClientIsCalledForIam();
+
+        thenIamClientIsReturned();
+        thenIamClientConstructedWitoutEndpoint();
+        thenIamClientConstructedWithNonGovGlobalRegion();
+    }
+
+    @Test
+    public void buildClient_returnsGovIamClient_whenGovRegionNullEndpoint() {
+        givenGovAwsRegion();
+        givenGoodCredentialsProvider();
+        givenNullEndpoint();
+        givenBuilderSucceeds();
+
+        whenBuildClientIsCalledForIam();
+
+        thenIamClientIsReturned();
+        thenIamClientConstructedWitoutEndpoint();
+        thenIamClientConstructedWithGovGlobalRegion();
+    }
+
+    @Test
+    public void buildClient_returnsNonGovIamClient_whenNonGovRegionEmptyEndpoint() {
+        givenNonGovAwsRegion();
+        givenGoodCredentialsProvider();
+        givenNullEndpoint();
+        givenBuilderSucceeds();
+
+        whenBuildClientIsCalledForIam();
+
+        thenIamClientIsReturned();
+        thenIamClientConstructedWitoutEndpoint();
+        thenIamClientConstructedWithNonGovGlobalRegion();
+    }
+
+    @Test
+    public void buildClient_returnsGovIamClient_whenGovRegionProvidedEndpoint() {
+        givenGovAwsRegion();
+        givenGoodCredentialsProvider();
+        givenGoodIamEndpoint();
+        givenBuilderSucceeds();
+
+        whenBuildClientIsCalledForIam();
+
+        thenIamClientIsReturned();
+        thenIamClientConstructedWithGovGlobalRegion();
+    }
+
+    // GIVENs
+    private void givenNonGovAwsRegion() {
+        given(mockAwsRequest.region()).willReturn("us-east-1");
+    }
+
+    private void givenGovAwsRegion() {
+        given(mockAwsRequest.region()).willReturn("us-gov-west-1");
+    }
+
+    private void givenGoodCredentialsProvider() {
+        given(mockAwsRequest.awsAccessKeyId()).willReturn("AKTESTTESTTEST");
+        given(mockAwsRequest.awsSecretAccessKey()).willReturn("SECRETSECRETSECRET");
+    }
+
+    private void givenNullEndpoint() {
+        given(mockAwsRequest.iamEndpoint()).willReturn(null);
+    }
+
+    private void givenEmptyEndpoint() {
+        given(mockAwsRequest.iamEndpoint()).willReturn("");
+    }
+
+    private void givenGoodIamEndpoint() {
+        given(mockAwsRequest.iamEndpoint()).willReturn("https://iam.amazonaws.com");
+    }
+
+    private void givenBuilderSucceeds() {
+        given(mockIamClientBuilder.build()).willReturn(mock(IamClient.class));
+    }
+
+    // WHENs
+    private void whenBuildClientIsCalledForIam() {
+        iamClient = AWSClientBuilderUtil.buildClient(mockIamClientBuilder, mockAwsRequest);
+    }
+
+    // THENs
+    private void thenIamClientIsReturned() {
+        assertThat(iamClient, notNullValue());
+    }
+
+    private void thenIamClientConstructedWithNonGovGlobalRegion() {
+        ArgumentCaptor<Region> regionCaptor = ArgumentCaptor.forClass(Region.class);
+        verify(mockIamClientBuilder, times(1)).region(regionCaptor.capture());
+
+        assertThat(regionCaptor.getValue(), notNullValue());
+        Region region = regionCaptor.getValue();
+        assertThat(region, is(Region.AWS_GLOBAL));
+    }
+
+    private void thenIamClientConstructedWithGovGlobalRegion() {
+        ArgumentCaptor<Region> regionCaptor = ArgumentCaptor.forClass(Region.class);
+        verify(mockIamClientBuilder, times(1)).region(regionCaptor.capture());
+
+        assertThat(regionCaptor.getValue(), notNullValue());
+        Region region = regionCaptor.getValue();
+        assertThat(region, is(Region.AWS_US_GOV_GLOBAL));
+    }
+
+    private void thenIamClientConstructedWitoutEndpoint() {
+        ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        verify(mockIamClientBuilder, times(0)).endpointOverride(uriCaptor.capture());
+    }
+
+    private void thenIamClientConstructedWithEndpoint() {
+        ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        verify(mockIamClientBuilder, times(1)).endpointOverride(uriCaptor.capture());
+
+        assertThat(uriCaptor.getValue(), notNullValue());
+    }
+}


### PR DESCRIPTION
The AWS Input was not working for GovCloud regions due to hard-coded region value when constructing the IAM client.  Additionally, the recommended policy was missing a permission that is more strictly enfoced on GovCloud.  This updates IAM client construction to work for GovCloud and adds the missing permission to the recommended policy.

Tested locally with GovCloud Access Key and Secret.