### PR TITLE
Add initial version of Palo Alto v9x plugin

### DIFF
--- a/src/main/java/org/graylog/integrations/IntegrationsModule.java
+++ b/src/main/java/org/graylog/integrations/IntegrationsModule.java
@@ -28,6 +28,8 @@ import org.graylog.integrations.aws.transports.AWSTransport;
 import org.graylog.integrations.aws.transports.KinesisTransport;
 import org.graylog.integrations.inputs.paloalto.PaloAltoCodec;
 import org.graylog.integrations.inputs.paloalto.PaloAltoTCPInput;
+import org.graylog.integrations.inputs.paloalto9.PaloAlto9xCodec;
+import org.graylog.integrations.inputs.paloalto9.PaloAlto9xInput;
 import org.graylog.integrations.ipfix.codecs.IpfixCodec;
 import org.graylog.integrations.ipfix.inputs.IpfixUdpInput;
 import org.graylog.integrations.ipfix.transports.IpfixUdpTransport;
@@ -90,10 +92,15 @@ public class IntegrationsModule extends PluginModule {
         addCodec("ipfix", IpfixCodec.class);
         addTransport("ipfix-udp", IpfixUdpTransport.class);
 
-        // Palo Alto Networks
+        // Palo Alto Networks 8x
         LOG.debug("Registering message input: {}", PaloAltoTCPInput.NAME);
         addMessageInput(PaloAltoTCPInput.class);
         addCodec(PaloAltoCodec.NAME, PaloAltoCodec.class);
+
+        // Palo Alto Networks 9x
+        LOG.debug("Registering message input: {}", PaloAlto9xInput.NAME);
+        addMessageInput(PaloAlto9xInput.class);
+        addCodec(PaloAlto9xCodec.NAME, PaloAlto9xCodec.class);
 
         // AWS
         addCodec(AWSCodec.NAME, AWSCodec.class);

--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoMessageTemplate.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoMessageTemplate.java
@@ -34,6 +34,7 @@ import java.util.Set;
 public class PaloAltoMessageTemplate {
 
     private Set<PaloAltoFieldTemplate> fields = new HashSet<>();
+
     private List<String> parseErrors = new ArrayList<>();
 
     public Set<PaloAltoFieldTemplate> getFields() {

--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoMessageType.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoMessageType.java
@@ -20,5 +20,9 @@ public enum PaloAltoMessageType {
 
     SYSTEM,
     THREAT,
-    TRAFFIC
+    TRAFFIC,
+    CONFIG,
+    CORRELATION,
+    HIP,
+    GLOBAL_PROTECT
 }

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodec.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodec.java
@@ -1,0 +1,170 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.integrations.inputs.paloalto9;
+
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
+import org.graylog.integrations.inputs.paloalto.PaloAltoMessageBase;
+import org.graylog.integrations.inputs.paloalto.PaloAltoParser;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.BooleanField;
+import org.graylog2.plugin.inputs.annotations.ConfigClass;
+import org.graylog2.plugin.inputs.annotations.FactoryClass;
+import org.graylog2.plugin.inputs.codecs.Codec;
+import org.graylog2.plugin.inputs.codecs.CodecAggregator;
+import org.graylog2.plugin.journal.RawMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.CONFIG;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.CORRELATION;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.GLOBAL_PROTECT;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.HIP;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.SYSTEM;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.THREAT;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.TRAFFIC;
+
+public class PaloAlto9xCodec implements Codec {
+    private static final Logger LOG = LoggerFactory.getLogger(PaloAlto9xCodec.class);
+
+    static final String CK_STORE_FULL_MESSAGE = "store_full_message";
+
+    public static final String NAME = "PaloAlto9x";
+
+    private final Configuration configuration;
+    private final PaloAltoParser rawMessageParser;
+    private final PaloAlto9xParser fieldProducer;
+
+    @AssistedInject
+    public PaloAlto9xCodec(@Assisted Configuration configuration, PaloAltoParser rawMessageParser, PaloAlto9xParser fieldProducer) {
+        this.configuration = configuration;
+        this.rawMessageParser = rawMessageParser;
+        this.fieldProducer = fieldProducer;
+    }
+
+    @Nullable
+    @Override
+    public Message decode(@Nonnull RawMessage rawMessage) {
+        String s = new String(rawMessage.getPayload());
+        LOG.trace("Received raw message: {}", s);
+
+        PaloAltoMessageBase p = rawMessageParser.parse(s);
+
+        // Return when error occurs parsing syslog header.
+        if (p == null) {
+            return null;
+        }
+
+        Message message = new Message(p.payload(), p.source(), p.timestamp());
+
+        switch (p.panType()) {
+            case "THREAT":
+                message.addFields(fieldProducer.parseFields(THREAT, p.fields()));
+                break;
+            case "SYSTEM":
+                message.addFields(fieldProducer.parseFields(SYSTEM, p.fields()));
+                break;
+            case "TRAFFIC":
+                message.addFields(fieldProducer.parseFields(TRAFFIC, p.fields()));
+                break;
+            case "CONFIG":
+                message.addFields(fieldProducer.parseFields(CONFIG, p.fields()));
+                break;
+            case "HIP-MATCH":
+            case "HIPMATCH":
+                message.addFields(fieldProducer.parseFields(HIP, p.fields()));
+                break;
+            case "CORRELATION":
+                message.addFields(fieldProducer.parseFields(CORRELATION, p.fields()));
+                break;
+            default:
+                // Global Protect messages have message type in position 5 rather than position 3
+                if (p.fields().get(5).equals("GLOBALPROTECT")) {
+                    message.addFields(fieldProducer.parseFields(GLOBAL_PROTECT, p.fields()));
+                    break;
+                } else {
+                    LOG.error("Unsupported PAN type [{}]. Not adding any parsed fields.", p.panType());
+                }
+        }
+
+        // Store full message if configured.
+        if (configuration.getBoolean(CK_STORE_FULL_MESSAGE)) {
+            message.addField(Message.FIELD_FULL_MESSAGE, new String(rawMessage.getPayload(), StandardCharsets.UTF_8));
+        }
+
+        LOG.trace("Successfully processed [{}] message with [{}] fields.", p.panType(), message.getFieldCount());
+
+        return message;
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    @Nonnull
+    @Override
+    public Configuration getConfiguration() {
+        return this.configuration;
+    }
+
+    @FactoryClass
+    public interface Factory extends Codec.Factory<PaloAlto9xCodec> {
+        @Override
+        PaloAlto9xCodec create(Configuration configuration);
+
+        @Override
+        PaloAlto9xCodec.Config getConfig();
+    }
+
+    @ConfigClass
+    public static class Config implements Codec.Config {
+        @Override
+        public ConfigurationRequest getRequestedConfiguration() {
+            final ConfigurationRequest r = new ConfigurationRequest();
+
+            r.addField(
+                    new BooleanField(
+                            CK_STORE_FULL_MESSAGE,
+                            "Store full message?",
+                            false,
+                            "Store the full original Palo Alto message as full_message?"
+                    )
+            );
+
+            return r;
+        }
+
+        @Override
+        public void overrideDefaultValues(@Nonnull ConfigurationRequest cr) {
+        }
+    }
+
+    @Nullable
+    @Override
+    public CodecAggregator getAggregator() {
+        return null;
+    }
+}

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xFields.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xFields.java
@@ -1,0 +1,85 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.integrations.inputs.paloalto9;
+
+public class PaloAlto9xFields {
+    public static final String PAN_AFTER_CHANGE_DETAIL = "pan_after_change_detail";
+    public static final String PAN_ALERT_DIRECTION = "pan_alert_direction";
+    public static final String PAN_ASSOC_ID = "pan_assoc_id";
+    public static final String PAN_AUTH_METHOD = "pan_auth_method";
+    public static final String PAN_BEFORE_CHANGE_DETAIL = "pan_before_change_detail";
+
+    public static final String PAN_CLOUD_HOSTNAME = "pan_cloud_hostname";
+    public static final String PAN_DEV_GROUP_LEVEL_1 = "pan_dev_group_level_1";
+    public static final String PAN_DEV_GROUP_LEVEL_2 = "pan_dev_group_level_2";
+    public static final String PAN_DEV_GROUP_LEVEL_3 = "pan_dev_group_level_3";
+    public static final String PAN_DEV_GROUP_LEVEL_4 = "pan_dev_group_level_4";
+
+    public static final String PAN_DYNUSERGROUP_NAME = "pan_dynusergroup_name";
+    public static final String PAN_EVENT_NAME = "pan_event_name";
+    public static final String PAN_EVENT_OBJECT = "pan_event_object";
+    public static final String PAN_EVIDENCE = "pan_evidence";
+    public static final String PAN_FLAGS = "pan_flags";
+
+    public static final String PAN_GP_CLIENT_VERSION = "pan_gp_client_version";
+    public static final String PAN_GP_CONNECT_METHOD = "pan_gp_connect_method";
+    public static final String PAN_GP_ERROR = "pan_gp_error";
+    public static final String PAN_GP_ERROR_CODE = "pan_gp_error_code";
+    public static final String PAN_GP_ERROR_EXTENDED = "pan_gp_error_extended";
+
+    public static final String PAN_GP_HOSTID = "pan_gp_hostid";
+    public static final String PAN_GP_HOSTNAME = "pan_gp_hostname";
+    public static final String PAN_GP_LOCATION_NAME = "pan_gp_location_name";
+    public static final String PAN_GP_REASON = "pan_gp_reason";
+    public static final String PAN_HIP = "pan_hip";
+
+    public static final String PAN_HIP_TYPE = "pan_hip_type";
+    public static final String PAN_HTTP2 = "pan_http2";
+    public static final String PAN_LINK_CHANGES = "pan_link_changes";
+    public static final String PAN_LINK_SWITCHES = "pan_link_switches";
+    public static final String PAN_LOG_ACITON = "pan_log_action";
+
+    public static final String PAN_LOG_PANORAMA = "pan_log_panorama";
+    public static final String PAN_LOG_SUBTYPE = "pan_log_subtype";
+    public static final String PAN_MODULE = "pan_module";
+    public static final String PAN_MONITOR_TAG = "pan_monitor_tag";
+    public static final String PAN_OBJECT_ID = "pan_object_id";
+
+    public static final String PAN_OBJECTNAME = "pan_objectname";
+    public static final String PAN_PARENT_SESSION_ID = "pan_parent_session_id";
+    public static final String PAN_PARENT_START_TIME = "pan_parent_start_time";
+    public static final String PAN_PCAP_ID = "pan_pcap_id";
+    public static final String PAN_PPID = "pan_ppid";
+
+    public static final String PAN_SCTP_CHUNKS_RX = "pan_sctp_chunks_rx";
+    public static final String PAN_SCTP_CHUNKS_SUM = "pan_sctp_chunks_sum";
+    public static final String PAN_SCTP_CHUNKS_TX = "pan_sctp_chunks_tx";
+    public static final String PAN_SDWAN_CLUSTER = "pan_sdwan_cluster";
+    public static final String PAN_SDWAN_CLUSTER_TYPE = "pan_sdwan_cluster_type";
+
+    public static final String PAN_SDWAN_DEVICE_TYPE = "pan_sdwan_device_type";
+    public static final String PAN_SDWAN_POLICY_ID = "pan_sdwan_policyid";
+    public static final String PAN_SDWAN_SITE_NAME = "pan_sdwan_site_name";
+    public static final String PAN_SESSION_END_REASON = "pan_session_end_reason";
+    public static final String PAN_SOURCE_REGION = "pan_source_region";
+
+    public static final String PAN_TUNNEL_ID = "pan_tunnel_id";
+    public static final String PAN_TUNNEL_STAGE = "pan_tunnel_stage";
+    public static final String PAN_URL_INDEX = "pan_url_index";
+    public static final String PAN_WILDFIRE_HASH = "pan_wildfire_hash";
+    public static final String PAN_WILDFIRE_REPORT_ID = "pan_wildfire_report_id";
+}

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xInput.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xInput.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog.integrations.inputs.paloalto;
+package org.graylog.integrations.inputs.paloalto9;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.assistedinject.Assisted;
@@ -32,25 +32,20 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 
-import static org.graylog.integrations.inputs.paloalto.PaloAltoCodec.CK_SYSTEM_TEMPLATE;
-import static org.graylog.integrations.inputs.paloalto.PaloAltoCodec.CK_THREAT_TEMPLATE;
-import static org.graylog.integrations.inputs.paloalto.PaloAltoCodec.CK_TRAFFIC_TEMPLATE;
+public class PaloAlto9xInput extends MessageInput {
+    private static final Logger LOG = LoggerFactory.getLogger(PaloAlto9xInput.class);
 
-public class PaloAltoTCPInput extends MessageInput {
-
-    public static final String NAME = "Palo Alto Networks TCP (PAN-OS v8.x)";
-
-    private static final Logger LOG = LoggerFactory.getLogger(PaloAltoTCPInput.class);
+    public static final String NAME = "Palo Alto Networks TCP (PAN-OS v9.x)";
 
     @Inject
-    public PaloAltoTCPInput(@Assisted Configuration configuration,
-                            MetricRegistry metricRegistry,
-                            SyslogTcpTransport.Factory transport,
-                            LocalMetricRegistry localRegistry,
-                            PaloAltoCodec.Factory codec,
-                            Config config,
-                            Descriptor descriptor,
-                            ServerStatus serverStatus) {
+    public PaloAlto9xInput(@Assisted Configuration configuration,
+                           MetricRegistry metricRegistry,
+                           SyslogTcpTransport.Factory transport,
+                           LocalMetricRegistry localRegistry,
+                           PaloAlto9xCodec.Factory codec,
+                           PaloAlto9xInput.Config config,
+                           PaloAlto9xInput.Descriptor descriptor,
+                           ServerStatus serverStatus) {
         super(
                 metricRegistry,
                 configuration,
@@ -64,29 +59,19 @@ public class PaloAltoTCPInput extends MessageInput {
 
     @Override
     public void launch(InputBuffer buffer) throws MisfireException {
-
-        // Parse the templates to log any errors immediately on input startup.
-        PaloAltoTemplates templates = PaloAltoTemplates.newInstance(configuration.getString(CK_SYSTEM_TEMPLATE, PaloAltoTemplateDefaults.SYSTEM_TEMPLATE),
-                configuration.getString(CK_THREAT_TEMPLATE, PaloAltoTemplateDefaults.THREAT_TEMPLATE),
-                configuration.getString(CK_TRAFFIC_TEMPLATE, PaloAltoTemplateDefaults.TRAFFIC_TEMPLATE));
-
-        if (templates.hasErrors()) {
-            throw new MisfireException(templates.errorMessageSummary("\n"));
-        }
-
         super.launch(buffer);
     }
 
     @FactoryClass
-    public interface Factory extends MessageInput.Factory<PaloAltoTCPInput> {
+    public interface Factory extends MessageInput.Factory<PaloAlto9xInput> {
         @Override
-        PaloAltoTCPInput create(Configuration configuration);
+        PaloAlto9xInput create(Configuration configuration);
 
         @Override
-        Config getConfig();
+        PaloAlto9xInput.Config getConfig();
 
         @Override
-        Descriptor getDescriptor();
+        PaloAlto9xInput.Descriptor getDescriptor();
     }
 
     public static class Descriptor extends MessageInput.Descriptor {
@@ -99,7 +84,7 @@ public class PaloAltoTCPInput extends MessageInput {
     public static class Config extends MessageInput.Config {
 
         @Inject
-        public Config(SyslogTcpTransport.Factory transport, PaloAltoCodec.Factory codec) {
+        public Config(SyslogTcpTransport.Factory transport, PaloAlto9xCodec.Factory codec) {
             super(transport.getConfig(), codec.getConfig());
         }
     }

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParser.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParser.java
@@ -1,0 +1,69 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.integrations.inputs.paloalto9;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import org.graylog.integrations.inputs.paloalto.PaloAltoMessageType;
+import org.graylog.integrations.inputs.paloalto.PaloAltoTypeParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class PaloAlto9xParser {
+    private static final Logger LOG = LoggerFactory.getLogger(PaloAlto9xParser.class);
+
+    private final Map<PaloAltoMessageType, PaloAltoTypeParser> parsers;
+
+    public PaloAlto9xParser() {
+        this(new PaloAltoTypeParser(PaloAlto9xTemplates.configTemplate(), PaloAltoMessageType.CONFIG),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.correlationTemplate(), PaloAltoMessageType.CORRELATION),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.globalProtectTemplate(), PaloAltoMessageType.GLOBAL_PROTECT),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.hipTemplate(), PaloAltoMessageType.HIP),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.systemTemplate(), PaloAltoMessageType.SYSTEM),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.threatTemplate(), PaloAltoMessageType.THREAT),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.trafficTemplate(), PaloAltoMessageType.TRAFFIC));
+    }
+
+    /* Package Private */ PaloAlto9xParser(PaloAltoTypeParser configParser,
+                                           PaloAltoTypeParser correlationParser,
+                                           PaloAltoTypeParser globalProtectParser,
+                                           PaloAltoTypeParser hipParser,
+                                           PaloAltoTypeParser systemParser,
+                                           PaloAltoTypeParser threatParser,
+                                           PaloAltoTypeParser trafficParser) {
+        parsers = Maps.newHashMap();
+        parsers.put(PaloAltoMessageType.CONFIG, configParser);
+        parsers.put(PaloAltoMessageType.CORRELATION, correlationParser);
+        parsers.put(PaloAltoMessageType.GLOBAL_PROTECT, globalProtectParser);
+        parsers.put(PaloAltoMessageType.HIP, hipParser);
+        parsers.put(PaloAltoMessageType.SYSTEM, systemParser);
+        parsers.put(PaloAltoMessageType.THREAT, threatParser);
+        parsers.put(PaloAltoMessageType.TRAFFIC, trafficParser);
+    }
+
+    public ImmutableMap<String, Object> parseFields(PaloAltoMessageType type, List<String> fields) {
+        if (parsers.containsKey(type)) {
+            PaloAltoTypeParser parser = parsers.get(type);
+            return parser.parseFields(fields);
+        }
+        LOG.error("Unsupported PAN type [{}]. Not adding any parsed fields.", type);
+        return ImmutableMap.of();
+    }
+}

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
@@ -1,0 +1,444 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.integrations.inputs.paloalto9;
+
+import com.google.common.collect.Sets;
+import org.graylog.integrations.inputs.paloalto.PaloAltoFieldTemplate;
+import org.graylog.integrations.inputs.paloalto.PaloAltoMessageTemplate;
+import org.graylog.schema.AlertFields;
+import org.graylog.schema.ApplicationFields;
+import org.graylog.schema.DestinationFields;
+import org.graylog.schema.EmailFields;
+import org.graylog.schema.EventFields;
+import org.graylog.schema.FileFields;
+import org.graylog.schema.HostFields;
+import org.graylog.schema.HttpFields;
+import org.graylog.schema.NetworkFields;
+import org.graylog.schema.SessionFields;
+import org.graylog.schema.SourceFields;
+import org.graylog.schema.ThreatFields;
+import org.graylog.schema.UserFields;
+import org.graylog.schema.VendorFields;
+import org.graylog2.plugin.Message;
+
+import java.util.Set;
+
+import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldTemplate.create;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.LONG;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.STRING;
+
+public class PaloAlto9xTemplates {
+
+    private static PaloAltoMessageTemplate toTemplate(Set<PaloAltoFieldTemplate> fields) {
+        PaloAltoMessageTemplate template = new PaloAltoMessageTemplate();
+        template.setFields(fields);
+        return template;
+    }
+
+    public static PaloAltoMessageTemplate configTemplate() {
+        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+
+        // Field 0 is FUTURE USE
+        fields.add(create(EventFields.EVENT_CREATED, 1, STRING));
+        fields.add(create(HostFields.HOST_ID, 2, STRING));
+        fields.add(create(EventFields.EVENT_LOG_NAME, 3, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
+
+        // Field 5 is FUTURE USE
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(SourceFields.SOURCE_REFERENCE, 7, STRING));
+        fields.add(create(HostFields.HOST_VIRTFW_ID, 8, STRING));
+        // Field 9 (command) is not mapped
+
+        fields.add(create(UserFields.USER_NAME, 10, STRING));
+        fields.add(create(VendorFields.VENDOR_SIGNIN_PROTOCOL, 11, STRING));
+        fields.add(create(VendorFields.VENDOR_EVENT_OUTCOME, 12, STRING));
+        fields.add(create(UserFields.USER_COMMAND, 13, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_BEFORE_CHANGE_DETAIL, 14, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_AFTER_CHANGE_DETAIL, 15, STRING));
+        fields.add(create(EventFields.EVENT_UID, 16, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_LOG_PANORAMA, 17, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_1, 18, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_2, 19, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_3, 20, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4, 21, STRING));
+        fields.add(create(HostFields.HOST_VIRTFW_HOSTNAME, 22, STRING));
+        fields.add(create(HostFields.HOST_HOSTNAME, 23, STRING));
+
+        return toTemplate(fields);
+    }
+
+    public static PaloAltoMessageTemplate correlationTemplate() {
+        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+
+        // Field 0 is FUTURE USE
+        fields.add(create(EventFields.EVENT_CREATED, 1, STRING));
+        fields.add(create(HostFields.HOST_ID, 2, STRING));
+        fields.add(create(EventFields.EVENT_LOG_NAME, 3, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
+
+        // Field 5 is FUTURE USE
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(SourceFields.SOURCE_IP, 7, STRING));
+        fields.add(create(SourceFields.SOURCE_USER, 8, STRING));
+        fields.add(create(HostFields.HOST_VIRTFW_ID, 9, STRING));
+
+        fields.add(create(ThreatFields.THREAT_CATEGORY, 10, STRING));
+        fields.add(create(EventFields.EVENT_SEVERITY, 11, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_1, 12, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_2, 13, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_3, 14, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4, 15, STRING));
+        fields.add(create(HostFields.HOST_VIRTFW_HOSTNAME, 16, STRING));
+        fields.add(create(HostFields.HOST_HOSTNAME, 17, STRING));
+        fields.add(create(HostFields.HOST_VIRTFW_UID, 18, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_OBJECTNAME, 19, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_OBJECT_ID, 20, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_EVIDENCE, 21, STRING));
+
+        return toTemplate(fields);
+    }
+
+    public static PaloAltoMessageTemplate hipTemplate() {
+        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+
+        // Field 0 is FUTURE USE
+        fields.add(create(EventFields.EVENT_CREATED, 1, STRING));
+        // fields.add(create(HostFields.HOST_ID, 2, STRING));  // TODO: Used twice
+        fields.add(create(EventFields.EVENT_LOG_NAME, 3, STRING));
+        fields.add(create("pan_log_subtype", 4, STRING));
+
+        // Field 5 is FUTURE USE
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(SourceFields.SOURCE_USER, 7, STRING));
+        fields.add(create(HostFields.HOST_VIRTFW_ID, 8, STRING));
+        fields.add(create(HostFields.HOST_HOSTNAME, 9, STRING)); // TODO: Used twice
+
+        fields.add(create(HostFields.HOST_TYPE, 10, STRING));
+        fields.add(create(SourceFields.SOURCE_IP, 11, STRING)); // TODO: Used twice
+        fields.add(create(PaloAlto9xFields.PAN_HIP, 12, STRING));
+        fields.add(create(EventFields.EVENT_REPEAT_COUNT, 13, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_HIP_TYPE, 14, STRING));
+
+        // Field 15 is FUTURE USE
+        // Field 16 is FUTURE USE
+        fields.add(create(EventFields.EVENT_UID, 17, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_LOG_PANORAMA, 18, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_1, 19, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_2, 20, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_3, 21, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4, 22, STRING));
+        fields.add(create(HostFields.HOST_VIRTFW_HOSTNAME, 23, STRING));
+        // fields.add(create(HostFields.HOST_HOSTNAME, 24, STRING)); // TODO: Used twice
+
+        fields.add(create(HostFields.HOST_VIRTFW_UID, 25, STRING));
+        // fields.add(create(SourceFields.SOURCE_IP, 26, STRING)); // TODO: Used twice
+        fields.add(create(PaloAlto9xFields.PAN_GP_HOSTID, 27, STRING));
+        fields.add(create(HostFields.HOST_ID, 28, STRING)); // TODO: Used twice
+
+        return toTemplate(fields);
+    }
+
+    public static PaloAltoMessageTemplate globalProtectTemplate() {
+        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+
+        // Field 0 is FUTURE USE
+        fields.add(create(EventFields.EVENT_RECEIVED_TIME, 1, STRING));
+        fields.add(create(HostFields.HOST_ID, 2, STRING));  // TODO: Used twice
+        fields.add(create(EventFields.EVENT_UID, 3, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_LOG_PANORAMA, 4, STRING));
+
+        fields.add(create(EventFields.EVENT_LOG_NAME, 5, STRING));
+        // Field 6 is FUTURE USE
+        // Field 7 is FUTURE USE
+        fields.add(create(Message.FIELD_TIMESTAMP, 8, STRING));
+        fields.add(create(HostFields.HOST_VIRTFW_ID, 9, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_EVENT_NAME, 10, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_TUNNEL_STAGE, 11, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_AUTH_METHOD, 12, STRING));
+        fields.add(create(NetworkFields.NETWORK_TUNNEL_TYPE, 13, STRING));
+        fields.add(create(SourceFields.SOURCE_USER_EMAIL, 14, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_SOURCE_REGION, 15, STRING));
+        fields.add(create(SourceFields.SOURCE_HOSTNAME, 16, STRING));
+        fields.add(create(VendorFields.VENDOR_PUBLIC_IP, 17, STRING));
+        fields.add(create(VendorFields.VENDOR_PUBLIC_IPV6, 18, STRING));
+        fields.add(create(VendorFields.VENDOR_PRIVATE_IP, 19, STRING));
+
+        fields.add(create(VendorFields.VENDOR_PRIVATE_IPV6, 20, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_GP_HOSTID, 21, STRING));
+        // fields.add(create(HostFields.HOST_ID, 22, STRING)); // TODO: Used twice
+        fields.add(create(PaloAlto9xFields.PAN_GP_CLIENT_VERSION, 23, STRING));
+        fields.add(create(HostFields.HOST_TYPE, 24, STRING));
+
+        fields.add(create(HostFields.HOST_TYPE_VERSION, 25, STRING));
+        fields.add(create(EventFields.EVENT_REPEAT_COUNT, 26, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_GP_REASON, 27, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_GP_ERROR, 28, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_GP_ERROR_EXTENDED, 29, STRING));
+
+        fields.add(create(VendorFields.VENDOR_EVENT_ACTION, 30, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_GP_LOCATION_NAME, 31, STRING));
+        fields.add(create(NetworkFields.NETWORK_TUNNEL_DURATION, 32, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_GP_CONNECT_METHOD, 33, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_GP_ERROR_CODE, 34, LONG));
+
+        fields.add(create(PaloAlto9xFields.PAN_GP_HOSTNAME, 35, STRING));
+
+
+        return toTemplate(fields);
+    }
+
+    public static PaloAltoMessageTemplate systemTemplate() {
+        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+
+        // Field 0 is FUTURE USE
+        fields.add(create(EventFields.EVENT_CREATED, 1, STRING));
+        fields.add(create(HostFields.HOST_ID, 2, STRING));
+        fields.add(create(EventFields.EVENT_LOG_NAME, 3, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
+
+        // Field 5 is FUTURE USE
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(HostFields.HOST_VIRTFW_ID, 7, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_EVENT_NAME, 8, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_EVENT_OBJECT, 9, STRING));
+
+        // Field 10 is FUTURE USE
+        // Field 11 is FUTURE USE
+        fields.add(create(PaloAlto9xFields.PAN_MODULE, 12, STRING));
+        fields.add(create(VendorFields.VENDOR_EVENT_SEVERITY, 13, STRING));
+        fields.add(create(VendorFields.VENDOR_EVENT_DESCRIPTION, 14, STRING));
+
+        fields.add(create(EventFields.EVENT_UID, 15, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_LOG_PANORAMA, 16, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_1, 17, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_2, 18, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_3, 19, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4, 20, STRING));
+        fields.add(create(HostFields.HOST_VIRTFW_HOSTNAME, 21, STRING));
+        fields.add(create(HostFields.HOST_HOSTNAME, 22, STRING));
+
+        return toTemplate(fields);
+    }
+
+    public static PaloAltoMessageTemplate threatTemplate() {
+        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+
+        // Field 0 is FUTURE USE
+        fields.add(create(EventFields.EVENT_RECEIVED_TIME, 1, STRING));
+        fields.add(create(HostFields.HOST_ID, 2, STRING));
+        fields.add(create(EventFields.EVENT_LOG_NAME, 3, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
+
+        // Field 5 is FUTURE USE
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(SourceFields.SOURCE_IP, 7, STRING));
+        fields.add(create(DestinationFields.DESTINATION_IP, 8, STRING));
+        fields.add(create(SourceFields.SOURCE_NAT_IP, 9, STRING));
+
+        fields.add(create(DestinationFields.DESTINATION_NAT_IP, 10, STRING));
+        fields.add(create("rule_name", 11, STRING)); // TODO: Need constant
+        fields.add(create(SourceFields.SOURCE_USER, 12, STRING));
+        fields.add(create("target_user_name", 13, STRING)); // TODO: Need constant
+        fields.add(create(ApplicationFields.APPLICATION_NAME, 14, STRING)); // TODO: Network Application?
+
+        fields.add(create(HostFields.HOST_VIRTFW_ID, 15, STRING));
+        fields.add(create(SourceFields.SOURCE_ZONE, 16, STRING));
+        fields.add(create(DestinationFields.DESTINATION_ZONE, 17, STRING));
+        fields.add(create(NetworkFields.NETWORK_INTERFACE_IN, 18, STRING));
+        fields.add(create(NetworkFields.NETWORK_INTERFACE_OUT, 19, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_LOG_ACITON, 20, STRING));
+        // Field 21 is FUTURE USE
+        fields.add(create(SessionFields.SESSION_ID, 22, LONG));
+        fields.add(create(EventFields.EVENT_REPEAT_COUNT, 23, LONG));
+        fields.add(create(SourceFields.SOURCE_PORT, 24, LONG));
+
+        fields.add(create(DestinationFields.DESTINATION_PORT, 25, LONG));
+        fields.add(create(SourceFields.SOURCE_NAT_PORT, 26, LONG));
+        fields.add(create(DestinationFields.DESTINATION_NAT_PORT, 27, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_FLAGS, 28, STRING));
+        fields.add(create(NetworkFields.NETWORK_PROTOCOL, 29, STRING));
+
+        fields.add(create(VendorFields.VENDOR_EVENT_ACTION, 30, STRING));
+        fields.add(create(HttpFields.HTTP_URL, 31, STRING));  // TODO: Dual-use position
+        fields.add(create(FileFields.FILE_NAME, 31, STRING)); // TODO: Dual-use position
+        fields.add(create(AlertFields.ALERT_SIGNATURE_ID, 32, STRING));
+        // fields.add(create(HttpFields.HTTP_URL_CATEGORY, 33, STRING));         // TODO: Dual-use position
+        fields.add(create(AlertFields.ALERT_SIGNATURE_CATEGORY, 33, STRING)); // TODO: Dual-use position
+        fields.add(create(VendorFields.VENDOR_ALERT_SEVERITY, 34, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_ALERT_DIRECTION, 35, STRING));
+        fields.add(create(EventFields.EVENT_UID, 36, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_LOG_PANORAMA, 37, STRING));
+        fields.add(create(SourceFields.SOURCE_LOCATION_NAME, 38, STRING));
+        fields.add(create(DestinationFields.DESTINATION_LOCATION_NAME, 39, STRING));
+
+        // Field 40 is FUTURE USE
+        fields.add(create(HttpFields.HTTP_CONTENT_TYPE, 41, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_PCAP_ID, 42, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_WILDFIRE_HASH, 43, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_CLOUD_HOSTNAME, 44, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_URL_INDEX, 45, LONG));
+        fields.add(create(HttpFields.HTTP_USER_AGENT_NAME, 46, STRING));
+        fields.add(create(FileFields.FILE_TYPE, 47, STRING));
+        fields.add(create(HttpFields.HTTP_XFF, 48, STRING));
+        fields.add(create(HttpFields.HTTP_REFERER, 49, STRING));
+
+        fields.add(create(SourceFields.SOURCE_USER_EMAIL, 50, STRING));
+        fields.add(create(EmailFields.EMAIL_SUBJECT, 51, STRING));
+        fields.add(create("target_user_email", 52, STRING)); // TODO: Need constant
+        fields.add(create(PaloAlto9xFields.PAN_WILDFIRE_REPORT_ID, 53, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_1, 54, LONG));
+
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_2, 55, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_3, 56, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4, 57, LONG));
+        fields.add(create(HostFields.HOST_VIRTFW_HOSTNAME, 58, STRING));
+        fields.add(create(HostFields.HOST_HOSTNAME, 59, STRING));
+
+        // Field 60 is FUTURE USE
+        fields.add(create(SourceFields.SOURCE_VSYS_UUID, 61, STRING));
+        fields.add(create(DestinationFields.DESTINATION_VSYS_UUID, 62, STRING));
+        fields.add(create(HttpFields.HTTP_METHOD, 63, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_TUNNEL_ID, 64, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_MONITOR_TAG, 65, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_PARENT_SESSION_ID, 66, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_PARENT_START_TIME, 67, STRING));
+        fields.add(create(NetworkFields.NETWORK_TUNNEL_TYPE, 68, STRING));
+        fields.add(create(AlertFields.ALERT_CATEGORY, 69, STRING));
+
+        fields.add(create(AlertFields.ALERT_DEFINITIONS_VERSION, 70, STRING));
+        // Field 71 is FUTURE USE
+        fields.add(create(PaloAlto9xFields.PAN_ASSOC_ID, 72, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_PPID, 73, LONG));
+        fields.add(create(HttpFields.HTTP_HEADERS, 74, STRING));
+
+        fields.add(create(HttpFields.HTTP_URL_CATEGORY, 75, STRING)); // TODO: Conflict with field 33?
+        fields.add(create("policy_uuid", 76, STRING));          // TODO: Need constant, also uid or uuid?
+        fields.add(create(PaloAlto9xFields.PAN_HTTP2, 77, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DYNUSERGROUP_NAME, 78, STRING));
+
+        return toTemplate(fields);
+    }
+
+    public static PaloAltoMessageTemplate trafficTemplate() {
+        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+
+        // Field 0 is FUTURE USE
+        fields.add(create(EventFields.EVENT_RECEIVED_TIME, 1, STRING));
+        fields.add(create(HostFields.HOST_ID, 2, STRING));
+        fields.add(create(EventFields.EVENT_LOG_NAME, 3, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
+
+        // Field 5 is FUTURE USE
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(SourceFields.SOURCE_IP, 7, STRING));
+        fields.add(create(DestinationFields.DESTINATION_IP, 8, STRING));
+        fields.add(create(SourceFields.SOURCE_NAT_IP, 9, STRING));
+
+        fields.add(create(DestinationFields.DESTINATION_NAT_IP, 10, STRING));
+        fields.add(create("rule_name", 11, STRING)); // TODO: Need constant
+        fields.add(create(SourceFields.SOURCE_USER, 12, STRING));
+        fields.add(create("target_user_name", 13, STRING)); // TODO: Need constant
+        fields.add(create(NetworkFields.NETWORK_APPLICATION, 14, STRING));
+
+        fields.add(create(HostFields.HOST_VIRTFW_ID, 15, STRING));
+        fields.add(create(SourceFields.SOURCE_ZONE, 16, STRING));
+        fields.add(create(DestinationFields.DESTINATION_ZONE, 17, STRING));
+        fields.add(create(NetworkFields.NETWORK_INTERFACE_IN, 18, STRING));
+        fields.add(create(NetworkFields.NETWORK_INTERFACE_OUT, 19, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_LOG_ACITON, 20, STRING));
+        // Field 21 is FUTURE USE
+        fields.add(create(SessionFields.SESSION_ID, 22, LONG));
+        fields.add(create(EventFields.EVENT_REPEAT_COUNT, 23, LONG));
+        fields.add(create(SourceFields.SOURCE_PORT, 24, LONG));
+
+        fields.add(create(DestinationFields.DESTINATION_PORT, 25, LONG));
+        fields.add(create(SourceFields.SOURCE_NAT_PORT, 26, LONG));
+        fields.add(create(DestinationFields.DESTINATION_NAT_PORT, 27, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_FLAGS, 28, STRING));
+        fields.add(create(NetworkFields.NETWORK_PROTOCOL, 29, STRING));
+
+        fields.add(create(VendorFields.VENDOR_EVENT_ACTION, 30, STRING));
+        fields.add(create(NetworkFields.NETWORK_BYTES, 31, LONG));
+        fields.add(create(NetworkFields.NETWORK_BYTES_TX, 32, LONG));
+        fields.add(create(NetworkFields.NETWORK_BYTES_RX, 33, LONG));
+        fields.add(create(NetworkFields.NETWORK_PACKETS, 34, LONG));
+
+        fields.add(create(EventFields.EVENT_START, 35, STRING));
+        fields.add(create(EventFields.EVENT_DURATION, 36, STRING));
+        fields.add(create(HttpFields.HTTP_URL_CATEGORY, 37, STRING));
+        // Field 38 is FUTURE USE
+        fields.add(create(EventFields.EVENT_UID, 39, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_LOG_PANORAMA, 40, STRING));
+        fields.add(create(SourceFields.SOURCE_LOCATION_NAME, 41, STRING));
+        fields.add(create(DestinationFields.DESTINATION_LOCATION_NAME, 42, STRING));
+        // Field 43 is FUTURE USE
+        fields.add(create(SourceFields.SOURCE_PACKETS, 44, LONG));
+
+        fields.add(create(DestinationFields.DESTINATION_PACKETS, 45, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_SESSION_END_REASON, 46, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_1, 47, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_2, 48, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_3, 49, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4, 50, STRING));
+        fields.add(create(HostFields.HOST_VIRTFW_HOSTNAME, 51, STRING));
+        fields.add(create(HostFields.HOST_HOSTNAME, 52, STRING));
+        fields.add(create(VendorFields.VENDOR_EVENT_DESCRIPTION, 53, STRING));
+        fields.add(create(SourceFields.SOURCE_VSYS_UUID, 54, STRING));
+
+        fields.add(create(DestinationFields.DESTINATION_VSYS_UUID, 55, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_TUNNEL_ID, 56, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_MONITOR_TAG, 57, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_PARENT_SESSION_ID, 58, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_PARENT_START_TIME, 59, STRING));
+
+        fields.add(create(NetworkFields.NETWORK_TUNNEL_TYPE, 60, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_ASSOC_ID, 61, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SCTP_CHUNKS_SUM, 62, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SCTP_CHUNKS_TX, 63, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SCTP_CHUNKS_RX, 64, STRING));
+
+        fields.add(create("policy_uid", 65, STRING)); // TODO: Need constant, also uid or uuid?
+        fields.add(create(PaloAlto9xFields.PAN_HTTP2, 66, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_LINK_CHANGES, 67, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SDWAN_POLICY_ID, 68, STRING)); // TODO: policy_id or policyid?
+        fields.add(create(PaloAlto9xFields.PAN_LINK_SWITCHES, 69, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_SDWAN_CLUSTER, 70, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SDWAN_DEVICE_TYPE, 71, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SDWAN_CLUSTER_TYPE, 72, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SDWAN_SITE_NAME, 73, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DYNUSERGROUP_NAME, 74, STRING));
+
+        return toTemplate(fields);
+    }
+}

--- a/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodecTest.java
+++ b/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodecTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -33,7 +32,7 @@ public class PaloAlto9xCodecTest {
     private static final String TEST_SOURCE = "Test Source";
     private static final DateTime TEST_DATE_TIME = DateTime.now();
     private static final String TEST_RAW_MESSAGE = "Foo,Bar,Baz";
-    private static final ImmutableList<String> TEST_FIELD_LIST = ImmutableList.of("Foo", "Bar", "Baz");
+    private static final ImmutableList<String> TEST_FIELD_LIST = ImmutableList.of("Foo", "Bar", "Baz", "Three", "Four", "GLOBALPROTECT");
     private static final ImmutableMap<String,Object> TEST_FIELD_MAP = ImmutableMap.of("field_one", "value_one",
             "field_two", "value_two",
             "field_three", Long.valueOf(3L));

--- a/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodecTest.java
+++ b/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodecTest.java
@@ -1,0 +1,224 @@
+package org.graylog.integrations.inputs.paloalto9;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.graylog.integrations.inputs.paloalto.PaloAltoMessageBase;
+import org.graylog.integrations.inputs.paloalto.PaloAltoMessageType;
+import org.graylog.integrations.inputs.paloalto.PaloAltoParser;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.journal.RawMessage;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PaloAlto9xCodecTest {
+    private static final String TEST_SOURCE = "Test Source";
+    private static final DateTime TEST_DATE_TIME = DateTime.now();
+    private static final String TEST_RAW_MESSAGE = "Foo,Bar,Baz";
+    private static final ImmutableList<String> TEST_FIELD_LIST = ImmutableList.of("Foo", "Bar", "Baz");
+    private static final ImmutableMap<String,Object> TEST_FIELD_MAP = ImmutableMap.of("field_one", "value_one",
+            "field_two", "value_two",
+            "field_three", Long.valueOf(3L));
+
+    // Code Under Test
+    @InjectMocks PaloAlto9xCodec cut;
+
+    // Mock Objects
+    @Mock Configuration mockConfig;
+    @Mock PaloAltoParser mockRawParser;
+    @Mock PaloAlto9xParser mockPaloParser;
+
+    // Test Objects
+    RawMessage in;
+    Message out;
+
+    // Test Cases
+    @Test
+    public void decode_runsSuccessfully_whenGoodConfigInput() {
+        givenGoodInputRawMessage();
+        givenPaloMessageType("CONFIG");
+        givenStoreFullMessage(false);
+        givenGoodFieldProducer();
+
+        whenDecodeIsCalled();
+
+        thenPaloParserCalledWithPaloMessageType(PaloAltoMessageType.CONFIG);
+        thenOutputMessageContainsExpectedFields(false);
+    }
+
+    @Test
+    public void decode_runsSuccessfully_whenGoodCorrelationInput() {
+        givenGoodInputRawMessage();
+        givenPaloMessageType("CORRELATION");
+        givenStoreFullMessage(true);
+        givenGoodFieldProducer();
+
+        whenDecodeIsCalled();
+
+        thenPaloParserCalledWithPaloMessageType(PaloAltoMessageType.CORRELATION);
+        thenOutputMessageContainsExpectedFields(true);
+    }
+
+    @Test
+    public void decode_runsSuccessfully_whenGoodGlobalProtectInput() {
+        givenGoodInputRawMessage();
+        givenPaloMessageType("GLOBALPROTECT");
+        givenStoreFullMessage(false);
+        givenGoodFieldProducer();
+
+        whenDecodeIsCalled();
+
+        thenPaloParserCalledWithPaloMessageType(PaloAltoMessageType.GLOBAL_PROTECT);
+        thenOutputMessageContainsExpectedFields(false);
+    }
+
+    @Test
+    public void decode_runsSuccessfully_whenGoodHipMatchInput() {
+        givenGoodInputRawMessage();
+        givenPaloMessageType("HIP-MATCH");
+        givenStoreFullMessage(true);
+        givenGoodFieldProducer();
+
+        whenDecodeIsCalled();
+
+        thenPaloParserCalledWithPaloMessageType(PaloAltoMessageType.HIP);
+        thenOutputMessageContainsExpectedFields(true);
+    }
+
+    @Test
+    public void decode_runsSuccessfully_whenNonStandardHipMatchInput() {
+        givenGoodInputRawMessage();
+        givenPaloMessageType("HIPMATCH");
+        givenStoreFullMessage(false);
+        givenGoodFieldProducer();
+
+        whenDecodeIsCalled();
+
+        thenPaloParserCalledWithPaloMessageType(PaloAltoMessageType.HIP);
+        thenOutputMessageContainsExpectedFields(false);
+    }
+
+    @Test
+    public void decode_runsSuccessfully_whenGoodSystemInput() {
+        givenGoodInputRawMessage();
+        givenPaloMessageType("SYSTEM");
+        givenStoreFullMessage(true);
+        givenGoodFieldProducer();
+
+        whenDecodeIsCalled();
+
+        thenPaloParserCalledWithPaloMessageType(PaloAltoMessageType.SYSTEM);
+        thenOutputMessageContainsExpectedFields(true);
+    }
+
+    @Test
+    public void decode_runsSuccessfully_whenGoodThreatInput() {
+        givenGoodInputRawMessage();
+        givenPaloMessageType("THREAT");
+        givenStoreFullMessage(false);
+        givenGoodFieldProducer();
+
+        whenDecodeIsCalled();
+
+        thenPaloParserCalledWithPaloMessageType(PaloAltoMessageType.THREAT);
+        thenOutputMessageContainsExpectedFields(false);
+    }
+
+    @Test
+    public void decode_runsSuccessfully_whenGoodTrafficInput() {
+        givenGoodInputRawMessage();
+        givenPaloMessageType("TRAFFIC");
+        givenStoreFullMessage(true);
+        givenGoodFieldProducer();
+
+        whenDecodeIsCalled();
+
+        thenPaloParserCalledWithPaloMessageType(PaloAltoMessageType.TRAFFIC);
+        thenOutputMessageContainsExpectedFields(true);
+    }
+
+    @Test
+    public void decode_returnsNull_whenRawPaloParseFails() {
+        givenGoodInputRawMessage();
+        givenRawParserReturnsNull();
+
+        whenDecodeIsCalled();
+
+        thenOutputMessageIsNull();
+    }
+
+    // GIVENs
+    private void givenGoodInputRawMessage() {
+        in = new RawMessage(TEST_RAW_MESSAGE.getBytes());
+    }
+
+    private void givenRawParserReturnsNull() {
+        given(mockRawParser.parse(anyString())).willReturn(null);
+    }
+
+    private void givenPaloMessageType(String panType) {
+        PaloAltoMessageBase foo = PaloAltoMessageBase.create(TEST_SOURCE, TEST_DATE_TIME, TEST_RAW_MESSAGE, panType,
+                TEST_FIELD_LIST);
+        given(mockRawParser.parse(anyString())).willReturn(foo);
+    }
+
+    private void givenStoreFullMessage(boolean storeFullMessage) {
+        given(mockConfig.getBoolean(PaloAlto9xCodec.CK_STORE_FULL_MESSAGE)).willReturn(storeFullMessage);
+    }
+
+    private void givenGoodFieldProducer() {
+        given(mockPaloParser.parseFields(any(PaloAltoMessageType.class), anyList())).willReturn(TEST_FIELD_MAP);
+    }
+
+    // WHENs
+    private void whenDecodeIsCalled() {
+        out = cut.decode(in);
+    }
+
+    // THENs
+    private void thenPaloParserCalledWithPaloMessageType(PaloAltoMessageType type) {
+        ArgumentCaptor<PaloAltoMessageType> typeCaptor = ArgumentCaptor.forClass(PaloAltoMessageType.class);
+        ArgumentCaptor<ImmutableList<String>> fieldsCaptor = ArgumentCaptor.forClass(ImmutableList.class);
+
+        verify(mockPaloParser, times(1)).parseFields(typeCaptor.capture(), fieldsCaptor.capture());
+
+        assertThat(typeCaptor.getValue(), is(type));
+        assertThat(fieldsCaptor.getValue(), is(TEST_FIELD_LIST));
+    }
+
+    private void thenOutputMessageContainsExpectedFields(boolean shouldContainFullMessage) {
+        assertThat(out, notNullValue());
+
+        assertThat(out.getField("field_one"), is("value_one"));
+        assertThat(out.getField("field_two"), is("value_two"));
+        assertThat(out.getField("field_three"), is(Long.valueOf(3L)));
+
+        if (shouldContainFullMessage) {
+            assertThat(out.getField(Message.FIELD_FULL_MESSAGE), is(TEST_RAW_MESSAGE));
+        } else {
+            assertThat(out.getField(Message.FIELD_FULL_MESSAGE), nullValue());
+        }
+    }
+
+    private void thenOutputMessageIsNull() {
+        assertThat(out, nullValue());
+    }
+}

--- a/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParserTest.java
+++ b/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParserTest.java
@@ -1,0 +1,279 @@
+package org.graylog.integrations.inputs.paloalto9;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.graylog.integrations.inputs.paloalto.PaloAltoMessageType;
+import org.graylog.integrations.inputs.paloalto.PaloAltoTypeParser;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PaloAlto9xParserTest {
+    private static final ImmutableList<String> TEST_FIELD_LIST = ImmutableList.of("Foo", "Bar", "Baz");
+    private static final ImmutableMap<String,Object> TEST_FIELD_MAP = ImmutableMap.of("field_one", "value_one",
+            "field_two", "value_two",
+            "field_three", Long.valueOf(3L));
+
+    // Code Under Test
+    PaloAlto9xParser cut;
+
+    // Mock Objects
+    @Mock PaloAltoTypeParser mockConfigParser;
+    @Mock PaloAltoTypeParser mockCorrelationParser;
+    @Mock PaloAltoTypeParser mockGlobalProtectParser;
+    @Mock PaloAltoTypeParser mockHipParser;
+    @Mock PaloAltoTypeParser mockSystemParser;
+    @Mock PaloAltoTypeParser mockThreatParser;
+    @Mock PaloAltoTypeParser mockTrafficParser;
+
+    // Test Objects
+    PaloAltoMessageType inputMessageType;
+    List<String> inputFields;
+    ImmutableMap<String, Object> outputFields;
+
+    // Set Up
+    @Before
+    public void setUp() {
+        cut = new PaloAlto9xParser(mockConfigParser,
+                mockCorrelationParser,
+                mockGlobalProtectParser,
+                mockHipParser,
+                mockSystemParser,
+                mockThreatParser,
+                mockTrafficParser);
+    }
+
+    // Test Cases
+    @Test
+    public void parseFields_returnExpectedFieldMap_whenConfigMessageType() {
+        givenInputFieldType(PaloAltoMessageType.CONFIG);
+        givenGoodInputFields();
+        givenGoodParsers();
+
+        whenParseFieldsIsCalled();
+
+        thenConfigParserIsUsed();
+        thenExpectedOutputIsReturned();
+    }
+
+    @Test
+    public void parseFields_returnExpectedFieldMap_whenCorrelationMessageType() {
+        givenInputFieldType(PaloAltoMessageType.CORRELATION);
+        givenGoodInputFields();
+        givenGoodParsers();
+
+        whenParseFieldsIsCalled();
+
+        thenCorrelationParserIsUsed();
+        thenExpectedOutputIsReturned();
+    }
+
+    @Test
+    public void parseFields_returnExpectedFieldMap_whenGlobalProtectMessageType() {
+        givenInputFieldType(PaloAltoMessageType.GLOBAL_PROTECT);
+        givenGoodInputFields();
+        givenGoodParsers();
+
+        whenParseFieldsIsCalled();
+
+        thenGlobalProtectParserIsUsed();
+        thenExpectedOutputIsReturned();
+    }
+
+    @Test
+    public void parseFields_returnExpectedFieldMap_whenHipMessageType() {
+        givenInputFieldType(PaloAltoMessageType.HIP);
+        givenGoodInputFields();
+        givenGoodParsers();
+
+        whenParseFieldsIsCalled();
+
+        thenHipParserIsUsed();
+        thenExpectedOutputIsReturned();
+    }
+
+    @Test
+    public void parseFields_returnExpectedFieldMap_whenSystemMessageType() {
+        givenInputFieldType(PaloAltoMessageType.SYSTEM);
+        givenGoodInputFields();
+        givenGoodParsers();
+
+        whenParseFieldsIsCalled();
+
+        thenSystemParserIsUsed();
+        thenExpectedOutputIsReturned();
+    }
+
+    @Test
+    public void parseFields_returnExpectedFieldMap_whenThreatMessageType() {
+        givenInputFieldType(PaloAltoMessageType.THREAT);
+        givenGoodInputFields();
+        givenGoodParsers();
+
+        whenParseFieldsIsCalled();
+
+        thenThreatParserIsUsed();
+        thenExpectedOutputIsReturned();
+    }
+
+    @Test
+    public void parseFields_returnExpectedFieldMap_whenTrafficMessageType() {
+        givenInputFieldType(PaloAltoMessageType.TRAFFIC);
+        givenGoodInputFields();
+        givenGoodParsers();
+
+        whenParseFieldsIsCalled();
+
+        thenTrafficParserIsUsed();
+        thenExpectedOutputIsReturned();
+    }
+
+    @Test
+    public void parseFields_returnsEmptyMap_whenNoParserFound() {
+        givenInputFieldType(null);
+        givenGoodInputFields();
+        givenGoodParsers();
+
+        whenParseFieldsIsCalled();
+
+        thenNoParserUsed();
+        thenEmptyMapReturned();
+    }
+
+    // GIVENs
+    private void givenInputFieldType(PaloAltoMessageType type) {
+        inputMessageType = type;
+    }
+
+    private void givenGoodInputFields() {
+        inputFields = TEST_FIELD_LIST;
+    }
+
+    private void givenGoodParsers() {
+        given(mockConfigParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
+        given(mockCorrelationParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
+        given(mockGlobalProtectParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
+        given(mockHipParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
+        given(mockSystemParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
+        given(mockThreatParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
+        given(mockTrafficParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
+    }
+
+    // WHENs
+    private void whenParseFieldsIsCalled() {
+        outputFields = cut.parseFields(inputMessageType, inputFields);
+    }
+
+    // THENs
+    private void thenConfigParserIsUsed() {
+        ArgumentCaptor<List<String>> fieldsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockConfigParser, times(1)).parseFields(fieldsCaptor.capture());
+        verifyNoMoreInteractions(mockCorrelationParser);
+        verifyNoMoreInteractions(mockGlobalProtectParser);
+        verifyNoMoreInteractions(mockHipParser);
+        verifyNoMoreInteractions(mockSystemParser);
+        verifyNoMoreInteractions(mockThreatParser);
+        verifyNoMoreInteractions(mockTrafficParser);
+    }
+
+    private void thenCorrelationParserIsUsed() {
+        ArgumentCaptor<List<String>> fieldsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockCorrelationParser, times(1)).parseFields(fieldsCaptor.capture());
+        verifyNoMoreInteractions(mockConfigParser);
+        verifyNoMoreInteractions(mockGlobalProtectParser);
+        verifyNoMoreInteractions(mockHipParser);
+        verifyNoMoreInteractions(mockSystemParser);
+        verifyNoMoreInteractions(mockThreatParser);
+        verifyNoMoreInteractions(mockTrafficParser);
+    }
+
+    private void thenGlobalProtectParserIsUsed() {
+        ArgumentCaptor<List<String>> fieldsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockGlobalProtectParser, times(1)).parseFields(fieldsCaptor.capture());
+        verifyNoMoreInteractions(mockConfigParser);
+        verifyNoMoreInteractions(mockCorrelationParser);
+        verifyNoMoreInteractions(mockHipParser);
+        verifyNoMoreInteractions(mockSystemParser);
+        verifyNoMoreInteractions(mockThreatParser);
+        verifyNoMoreInteractions(mockTrafficParser);
+    }
+
+    private void thenHipParserIsUsed() {
+        ArgumentCaptor<List<String>> fieldsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockHipParser, times(1)).parseFields(fieldsCaptor.capture());
+        verifyNoMoreInteractions(mockConfigParser);
+        verifyNoMoreInteractions(mockCorrelationParser);
+        verifyNoMoreInteractions(mockGlobalProtectParser);
+        verifyNoMoreInteractions(mockSystemParser);
+        verifyNoMoreInteractions(mockThreatParser);
+        verifyNoMoreInteractions(mockTrafficParser);
+    }
+
+    private void thenSystemParserIsUsed() {
+        ArgumentCaptor<List<String>> fieldsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockSystemParser, times(1)).parseFields(fieldsCaptor.capture());
+        verifyNoMoreInteractions(mockConfigParser);
+        verifyNoMoreInteractions(mockCorrelationParser);
+        verifyNoMoreInteractions(mockGlobalProtectParser);
+        verifyNoMoreInteractions(mockHipParser);
+        verifyNoMoreInteractions(mockThreatParser);
+        verifyNoMoreInteractions(mockTrafficParser);
+    }
+
+    private void thenThreatParserIsUsed() {
+        ArgumentCaptor<List<String>> fieldsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockThreatParser, times(1)).parseFields(fieldsCaptor.capture());
+        verifyNoMoreInteractions(mockConfigParser);
+        verifyNoMoreInteractions(mockCorrelationParser);
+        verifyNoMoreInteractions(mockGlobalProtectParser);
+        verifyNoMoreInteractions(mockHipParser);
+        verifyNoMoreInteractions(mockSystemParser);
+        verifyNoMoreInteractions(mockTrafficParser);
+    }
+
+    private void thenTrafficParserIsUsed() {
+        ArgumentCaptor<List<String>> fieldsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockTrafficParser, times(1)).parseFields(fieldsCaptor.capture());
+        verifyNoMoreInteractions(mockConfigParser);
+        verifyNoMoreInteractions(mockCorrelationParser);
+        verifyNoMoreInteractions(mockGlobalProtectParser);
+        verifyNoMoreInteractions(mockHipParser);
+        verifyNoMoreInteractions(mockSystemParser);
+        verifyNoMoreInteractions(mockThreatParser);
+    }
+
+    private void thenNoParserUsed() {
+        verifyNoMoreInteractions(mockConfigParser);
+        verifyNoMoreInteractions(mockCorrelationParser);
+        verifyNoMoreInteractions(mockGlobalProtectParser);
+        verifyNoMoreInteractions(mockHipParser);
+        verifyNoMoreInteractions(mockSystemParser);
+        verifyNoMoreInteractions(mockThreatParser);
+        verifyNoMoreInteractions(mockTrafficParser);
+    }
+
+    private void thenExpectedOutputIsReturned() {
+        assertThat(outputFields, notNullValue());
+        assertThat(outputFields, is(TEST_FIELD_MAP));
+    }
+
+    private void thenEmptyMapReturned() {
+        assertThat(outputFields, notNullValue());
+        assertThat(outputFields.size(), is(0));
+    }
+}

--- a/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplatesTest.java
+++ b/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplatesTest.java
@@ -1,0 +1,224 @@
+package org.graylog.integrations.inputs.paloalto9;
+
+import com.google.common.collect.ImmutableMap;
+import org.graylog.integrations.inputs.paloalto.PaloAltoParser;
+import org.graylog.schema.EventFields;
+import org.graylog.schema.HostFields;
+import org.graylog.schema.NetworkFields;
+import org.graylog.schema.SourceFields;
+import org.graylog.schema.ThreatFields;
+import org.graylog.schema.UserFields;
+import org.graylog.schema.VendorFields;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.configuration.Configuration;
+import org.graylog2.plugin.journal.RawMessage;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class PaloAlto9xTemplatesTest {
+    private static final String SYSLOG_PREFIX = "<14>1 2020-06-02T14:01:00.000Z PYTHON_TEST_SENDER - - - - ";
+    
+    // Code Under Test
+    PaloAlto9xCodec cut;
+
+    @Before
+    public void setUp() {
+        Configuration config = new Configuration(ImmutableMap.of(PaloAlto9xCodec.CK_STORE_FULL_MESSAGE, true));
+        PaloAltoParser rawParser = new PaloAltoParser();
+        PaloAlto9xParser palo9xParser = new PaloAlto9xParser();
+        cut = new PaloAlto9xCodec(config, rawParser, palo9xParser);
+    }
+
+    @Test
+    public void verifyConfigurationMessageParsing() {
+        String log = "1,2020/05/26 04:11:09,007000000018919,CONFIG,0,0,2020/05/26 04:11:09,86.181.133.251,,multi-clone,aduncan@paloaltonetworks.com,Web,Succeeded,vsys  vsys1 profiles virus,,default-1  { decoder { http  { action default; wildfire-action default; } http2  { action default; wildfire-action default; } smtp  { action default; wildfire-action default; } imap  { action default; wildfire-action default; } pop3  { action default; wildfire-action default; } ftp  { action default; wildfire-action default; } smb  { action default; wildfire-action default; } } } ,5481,0x8000000000000000,0,0,0,0,,uk1,0,";
+        String rawMessage = SYSLOG_PREFIX + log;
+        RawMessage in = new RawMessage(rawMessage.getBytes());
+
+        Message out = cut.decode(in);
+
+        assertThat(out, notNullValue());
+        assertThat(out.getField(Message.FIELD_FULL_MESSAGE), is(rawMessage));
+        assertThat(out.getField(Message.FIELD_MESSAGE), is(log));
+        
+        assertThat(out.getField(EventFields.EVENT_CREATED), is("2020/05/26 04:11:09"));
+        assertThat(out.getField(HostFields.HOST_ID), is("007000000018919"));
+        assertThat(out.getField(EventFields.EVENT_LOG_NAME), is("CONFIG"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_LOG_SUBTYPE), is("0"));
+        assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2020/05/26 04:11:09"));
+        assertThat(out.getField(SourceFields.SOURCE_REFERENCE), is("86.181.133.251"));
+        assertThat(out.getField(HostFields.HOST_VIRTFW_ID), nullValue());
+        assertThat(out.getField(UserFields.USER_NAME), is("aduncan@paloaltonetworks.com"));
+        assertThat(out.getField(VendorFields.VENDOR_SIGNIN_PROTOCOL), is("Web"));
+        assertThat(out.getField(VendorFields.VENDOR_EVENT_OUTCOME), is("Succeeded"));
+        assertThat(out.getField(UserFields.USER_COMMAND), is("vsys  vsys1 profiles virus"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_BEFORE_CHANGE_DETAIL), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_AFTER_CHANGE_DETAIL), is("default-1  { decoder { http  { action default; wildfire-action default; } http2  { action default; wildfire-action default; } smtp  { action default; wildfire-action default; } imap  { action default; wildfire-action default; } pop3  { action default; wildfire-action default; } ftp  { action default; wildfire-action default; } smb  { action default; wildfire-action default; } } }"));
+        assertThat(out.getField(EventFields.EVENT_UID), is("5481"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_LOG_PANORAMA), is("0x8000000000000000"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_1), is("0"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_2), is("0"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_3), is("0"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4), is("0"));
+        assertThat(out.getField(HostFields.HOST_VIRTFW_HOSTNAME), nullValue());
+        assertThat(out.getField(HostFields.HOST_HOSTNAME), is("uk1"));
+    }
+
+    @Test
+    public void verifyCorrelationMessageParsing() {
+        String log = "1,2020/05/31 17:19:44,0007SE00209,CORRELATION,,,2020/05/31 17:19:44,10.154.8.125,pancademo\\david.mccoy,,compromised-host,medium,31,40,0,0,,uk1rama,,beacon-heuristics,6005,\"Host has made use of Internet Relay Chat (IRC), a protocol popular with command-and-control activity.\"";
+        String rawMessage = SYSLOG_PREFIX + log;
+        RawMessage in = new RawMessage(rawMessage.getBytes());
+
+        Message out = cut.decode(in);
+
+        assertThat(out, notNullValue());
+        assertThat(out.getField(Message.FIELD_FULL_MESSAGE), is(rawMessage));
+        assertThat(out.getField(Message.FIELD_MESSAGE), is(log));
+
+        assertThat(out.getField(EventFields.EVENT_CREATED), is("2020/05/31 17:19:44"));
+        assertThat(out.getField(HostFields.HOST_ID), is("0007SE00209"));
+        assertThat(out.getField(EventFields.EVENT_LOG_NAME), is("CORRELATION"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_LOG_SUBTYPE), nullValue());
+        assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2020/05/31 17:19:44"));
+        assertThat(out.getField(SourceFields.SOURCE_IP), is("10.154.8.125"));
+        assertThat(out.getField(SourceFields.SOURCE_USER), is("pancademo\\david.mccoy"));
+        assertThat(out.getField(HostFields.HOST_VIRTFW_ID), nullValue());
+        assertThat(out.getField(ThreatFields.THREAT_CATEGORY), is("compromised-host"));
+        assertThat(out.getField(EventFields.EVENT_SEVERITY), is("medium"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_1), is("31"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_2), is("40"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_3), is("0"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4), is("0"));
+        assertThat(out.getField(HostFields.HOST_VIRTFW_HOSTNAME), nullValue());
+        assertThat(out.getField(HostFields.HOST_HOSTNAME), is("uk1rama"));
+        assertThat(out.getField(HostFields.HOST_VIRTFW_UID), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_OBJECTNAME), is("beacon-heuristics"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_OBJECT_ID), is("6005"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_EVIDENCE), is("Host has made use of Internet Relay Chat (IRC), a protocol popular with command-and-control activity."));
+    }
+
+    @Test
+    public void verifyGlobalProtectMessageParsing() {
+        String log = "1,2020/04/01 10:49:35,015351000040055,11,0x0,GLOBALPROTECT,0,2305,2020/04/01 10:49:35,vsys1,portal-prelogin,before-login,,,,192.168.0.0-192.168.255.255,,192.168.45.33,0.0.0.0,0.0.0.0,0.0.0.0,2c2ec970-de09-444c-b84f-2c0be75e13cd,,Browser,Windows,\"Microsoft Windows 7  Service Pack 1, 64-bit\",1,,,\"\",success,,0,,0,gp-portal";
+        String rawMessage = SYSLOG_PREFIX + log;
+        RawMessage in = new RawMessage(rawMessage.getBytes());
+
+        Message out = cut.decode(in);
+
+        assertThat(out, notNullValue());
+        assertThat(out.getField(Message.FIELD_FULL_MESSAGE), is(rawMessage));
+        assertThat(out.getField(Message.FIELD_MESSAGE), is(log));
+
+        assertThat(out.getField(EventFields.EVENT_RECEIVED_TIME), is("2020/04/01 10:49:35"));
+        assertThat(out.getField(HostFields.HOST_ID), is("015351000040055"));
+        assertThat(out.getField(EventFields.EVENT_UID), is("11"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_LOG_PANORAMA), is("0x0"));
+        assertThat(out.getField(EventFields.EVENT_LOG_NAME), is("GLOBALPROTECT"));
+        assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2020/04/01 10:49:35"));
+        assertThat(out.getField(HostFields.HOST_VIRTFW_ID), is("vsys1"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_EVENT_NAME), is("portal-prelogin"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_TUNNEL_STAGE), is("before-login"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_AUTH_METHOD), nullValue());
+        assertThat(out.getField(NetworkFields.NETWORK_TUNNEL_TYPE), nullValue());
+        assertThat(out.getField(SourceFields.SOURCE_USER_EMAIL), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_SOURCE_REGION), is("192.168.0.0-192.168.255.255"));
+        assertThat(out.getField(SourceFields.SOURCE_HOSTNAME), nullValue());
+        assertThat(out.getField(VendorFields.VENDOR_PUBLIC_IP), is("192.168.45.33"));
+        assertThat(out.getField(VendorFields.VENDOR_PUBLIC_IPV6), is("0.0.0.0"));
+        assertThat(out.getField(VendorFields.VENDOR_PRIVATE_IP), is("0.0.0.0"));
+        assertThat(out.getField(VendorFields.VENDOR_PRIVATE_IPV6), is("0.0.0.0"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_GP_HOSTID), is("2c2ec970-de09-444c-b84f-2c0be75e13cd"));
+        // assertThat(out.getField(HostFields.HOST_ID), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_GP_CLIENT_VERSION), is("Browser"));
+        assertThat(out.getField(HostFields.HOST_TYPE), is("Windows"));
+        assertThat(out.getField(HostFields.HOST_TYPE_VERSION), is("Microsoft Windows 7  Service Pack 1, 64-bit"));
+        assertThat(out.getField(EventFields.EVENT_REPEAT_COUNT), is(1L));
+        assertThat(out.getField(PaloAlto9xFields.PAN_GP_REASON), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_GP_ERROR), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_GP_ERROR_EXTENDED), nullValue());
+        assertThat(out.getField(VendorFields.VENDOR_EVENT_ACTION), is("success"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_GP_LOCATION_NAME), nullValue());
+        assertThat(out.getField(NetworkFields.NETWORK_TUNNEL_DURATION), is(0L));
+        assertThat(out.getField(PaloAlto9xFields.PAN_GP_CONNECT_METHOD), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_GP_ERROR_CODE), is(0L));
+        assertThat(out.getField(PaloAlto9xFields.PAN_GP_HOSTNAME), is("gp-portal"));
+    }
+
+    @Test
+    public void verifyHipMatchMessageParsing() {
+        String log = "0,2020/03/18 04:03:19,,HIPMATCH,0,0,2020/03/18 04:02:55,user1@prismaissase.com,vsys1,DFWMACW12KG8WL,Mac,172.1.19.3,test-Object,1,object,0,0,28,0x8600000000000000,15,18,0,0,,GP cloud service,1,0.0.0.0,4c:32:75:9a:5f:ed,";
+        String rawMessage = SYSLOG_PREFIX + log;
+        RawMessage in = new RawMessage(rawMessage.getBytes());
+
+        Message out = cut.decode(in);
+
+        assertThat(out, notNullValue());
+        assertThat(out.getField(Message.FIELD_FULL_MESSAGE), is(rawMessage));
+        assertThat(out.getField(Message.FIELD_MESSAGE), is(log));
+    }
+
+    @Test
+    public void verifySystemMessageParsing() {
+        String log = "1,2020/03/19 10:12:57,007000016479,SYSTEM,general,0,2020/03/19 10:12:57,,general,,0,0,general,informational,\"Failed to connect to address: (null) port: 3978, conn id: triallr-(null)-2-192.168.1.232\",21682381,0x8000000000000000,0,0,0,0,,sg2";
+        String rawMessage = SYSLOG_PREFIX + log;
+        RawMessage in = new RawMessage(rawMessage.getBytes());
+
+        Message out = cut.decode(in);
+
+        assertThat(out, notNullValue());
+        assertThat(out.getField(Message.FIELD_FULL_MESSAGE), is(rawMessage));
+        assertThat(out.getField(Message.FIELD_MESSAGE), is(log));
+        
+        assertThat(out.getField(EventFields.EVENT_CREATED), is("2020/03/19 10:12:57"));
+        assertThat(out.getField(HostFields.HOST_ID), is("007000016479"));
+        assertThat(out.getField(EventFields.EVENT_LOG_NAME), is("SYSTEM"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_LOG_SUBTYPE), is("general"));
+        assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2020/03/19 10:12:57"));
+        assertThat(out.getField(HostFields.HOST_VIRTFW_ID), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_EVENT_NAME), is("general"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_EVENT_OBJECT), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_MODULE), is("general"));
+        assertThat(out.getField(VendorFields.VENDOR_EVENT_SEVERITY), is("informational"));
+        assertThat(out.getField(VendorFields.VENDOR_EVENT_DESCRIPTION), is("Failed to connect to address: (null) port: 3978, conn id: triallr-(null)-2-192.168.1.232"));
+        assertThat(out.getField(EventFields.EVENT_UID), is("21682381"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_LOG_PANORAMA), is("0x8000000000000000"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_1), is("0"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_2), is("0"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_3), is("0"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4), is("0"));
+        assertThat(out.getField(HostFields.HOST_VIRTFW_HOSTNAME), nullValue());
+        assertThat(out.getField(HostFields.HOST_HOSTNAME), is("sg2"));
+    }
+
+    @Test
+    public void verifyThreatMessageParsing() {
+        String log = "1,2020/05/19 07:37:27,007200002536,THREAT,spyware,2305,2020/05/19 07:37:27,10.154.229.167,190.253.254.254,,,General Business Apps,pancademo\\andy.miller,,unknown-udp,vsys1,L3-TAP,L3-TAP,ethernet1/2,ethernet1/2,,2020/05/19 07:37:27,70860,1,1111,16471,0,0,0x80002000,udp,drop,\"\",ZeroAccess.Gen Command and Control Traffic(13235),any,critical,client-to-server,6241468001,0x2000000000000000,10.0.0.0-10.255.255.255,Colombia,0,,1206236073597030482,,,0,,,,,,,,0,31,12,0,0,,us1,,,,,0,,0,,N/A,botnet,AppThreat-8270-6076,0x0,0,4294967295,,,f0724261-cf8b-479b-8208-fd3c7ac3af0b,0,";
+        String rawMessage = SYSLOG_PREFIX + log;
+        RawMessage in = new RawMessage(rawMessage.getBytes());
+
+        Message out = cut.decode(in);
+
+        assertThat(out, notNullValue());
+        assertThat(out.getField(Message.FIELD_FULL_MESSAGE), is(rawMessage));
+        assertThat(out.getField(Message.FIELD_MESSAGE), is(log));
+    }
+
+    @Test
+    public void verifyTrafficMessageParsing() {
+        String log = "1,2020/05/19 07:34:54,007200002536,TRAFFIC,end,2305,2020/05/19 07:34:54,10.154.172.134,151.151.88.132,,,IT Sanctioned SaaS Apps-443,pancademo\\steven.reid,,ssl,vsys1,L3-TAP,L3-TAP,ethernet1/2,ethernet1/2,,2020/05/19 07:34:54,33903,1,57090,443,0,0,0x6c,tcp,allow,6802,3876,2926,26,2020/05/19 07:32:48,97,financial-services,0,18621234943,0x0,10.0.0.0-10.255.255.255,United States,0,17,9,tcp-rst-from-server,31,12,0,0,,us1,from-policy,,,0,,0,,N/A,0,0,0,0,30468339-a760-46b2-b80b-ee873e6d11e4,0,0,,,,,,,";
+        String rawMessage = SYSLOG_PREFIX + log;
+        RawMessage in = new RawMessage(rawMessage.getBytes());
+
+        Message out = cut.decode(in);
+
+        assertThat(out, notNullValue());
+        assertThat(out.getField(Message.FIELD_FULL_MESSAGE), is(rawMessage));
+        assertThat(out.getField(Message.FIELD_MESSAGE), is(log));
+    }
+}

--- a/src/test/python/send_syslog.py
+++ b/src/test/python/send_syslog.py
@@ -71,6 +71,7 @@ class SyslogSender(object):
 
 def send_single_message(client, message):
     client.send(message)
+    client.close()
 
 
 def send_messages_from_file(client, file):
@@ -78,6 +79,7 @@ def send_messages_from_file(client, file):
     for line in input_file:
         client.send(line)
     input_file.close()
+    client.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The Palo Alto v9x plugin is built on the existing code for Palo v8.  This new plugin handles the PAN-OS v9.x schema and adds four new message types.  However, it no longer supports user-defined schemas.  Instead, it parses messages into the new Graylog Schema.

Changes have been tested with JUnits and by pushing a variety of PAN-OS 9.x messages into a local Graylog instance.

There are still some changes that need to be made in the templates, as noted by the TODO comments.