### PR TITLE
Update Palo 9.x to handle 9.1.3 GlobalProtect logs - Fixes #540 (#541)

### DIFF
--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoMessageType.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoMessageType.java
@@ -24,5 +24,6 @@ public enum PaloAltoMessageType {
     CONFIG,
     CORRELATION,
     HIP,
-    GLOBAL_PROTECT
+    GLOBAL_PROTECT_PRE_9_1_3,
+    GLOBAL_PROTECT_9_1_3
 }

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodec.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodec.java
@@ -39,7 +39,8 @@ import java.nio.charset.StandardCharsets;
 
 import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.CONFIG;
 import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.CORRELATION;
-import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.GLOBAL_PROTECT;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.GLOBAL_PROTECT_PRE_9_1_3;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.GLOBAL_PROTECT_9_1_3;
 import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.HIP;
 import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.SYSTEM;
 import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.THREAT;
@@ -98,10 +99,14 @@ public class PaloAlto9xCodec implements Codec {
             case "CORRELATION":
                 message.addFields(fieldProducer.parseFields(CORRELATION, p.fields()));
                 break;
+            case "GLOBALPROTECT":
+                // For PAN v9.1.3 and later, Global Protect has type in the expected position
+                message.addFields(fieldProducer.parseFields(GLOBAL_PROTECT_9_1_3, p.fields()));
+                break;
             default:
-                // Global Protect messages have message type in position 5 rather than position 3
+                //For PAN v9.1.2 and earlier, Global Protect has type in position 5 rather than position 3
                 if (p.fields().get(5).equals("GLOBALPROTECT")) {
-                    message.addFields(fieldProducer.parseFields(GLOBAL_PROTECT, p.fields()));
+                    message.addFields(fieldProducer.parseFields(GLOBAL_PROTECT_PRE_9_1_3, p.fields()));
                     break;
                 } else {
                     LOG.error("Unsupported PAN type [{}]. Not adding any parsed fields.", p.panType());

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParser.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParser.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.integrations.inputs.paloalto9;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import org.graylog.integrations.inputs.paloalto.PaloAltoMessageType;
@@ -34,16 +35,19 @@ public class PaloAlto9xParser {
     public PaloAlto9xParser() {
         this(new PaloAltoTypeParser(PaloAlto9xTemplates.configTemplate(), PaloAltoMessageType.CONFIG),
                 new PaloAltoTypeParser(PaloAlto9xTemplates.correlationTemplate(), PaloAltoMessageType.CORRELATION),
-                new PaloAltoTypeParser(PaloAlto9xTemplates.globalProtectTemplate(), PaloAltoMessageType.GLOBAL_PROTECT),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.globalProtectPre913Template(), PaloAltoMessageType.GLOBAL_PROTECT_PRE_9_1_3),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.globalProtect913Template(), PaloAltoMessageType.GLOBAL_PROTECT_9_1_3),
                 new PaloAltoTypeParser(PaloAlto9xTemplates.hipTemplate(), PaloAltoMessageType.HIP),
                 new PaloAltoTypeParser(PaloAlto9xTemplates.systemTemplate(), PaloAltoMessageType.SYSTEM),
                 new PaloAltoTypeParser(PaloAlto9xTemplates.threatTemplate(), PaloAltoMessageType.THREAT),
                 new PaloAltoTypeParser(PaloAlto9xTemplates.trafficTemplate(), PaloAltoMessageType.TRAFFIC));
     }
 
-    /* Package Private */ PaloAlto9xParser(PaloAltoTypeParser configParser,
+    @VisibleForTesting
+    PaloAlto9xParser(PaloAltoTypeParser configParser,
                                            PaloAltoTypeParser correlationParser,
-                                           PaloAltoTypeParser globalProtectParser,
+                                           PaloAltoTypeParser globalProtectPre913Parser,
+                                           PaloAltoTypeParser globalProtect913Parser,
                                            PaloAltoTypeParser hipParser,
                                            PaloAltoTypeParser systemParser,
                                            PaloAltoTypeParser threatParser,
@@ -51,7 +55,8 @@ public class PaloAlto9xParser {
         parsers = Maps.newHashMap();
         parsers.put(PaloAltoMessageType.CONFIG, configParser);
         parsers.put(PaloAltoMessageType.CORRELATION, correlationParser);
-        parsers.put(PaloAltoMessageType.GLOBAL_PROTECT, globalProtectParser);
+        parsers.put(PaloAltoMessageType.GLOBAL_PROTECT_PRE_9_1_3, globalProtectPre913Parser);
+        parsers.put(PaloAltoMessageType.GLOBAL_PROTECT_9_1_3, globalProtect913Parser);
         parsers.put(PaloAltoMessageType.HIP, hipParser);
         parsers.put(PaloAltoMessageType.SYSTEM, systemParser);
         parsers.put(PaloAltoMessageType.THREAT, threatParser);

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
@@ -158,7 +158,7 @@ public class PaloAlto9xTemplates {
         return toTemplate(fields);
     }
 
-    public static PaloAltoMessageTemplate globalProtectTemplate() {
+    public static PaloAltoMessageTemplate globalProtectPre913Template() {
         Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
 
         // Field 0 is FUTURE USE
@@ -205,6 +205,56 @@ public class PaloAlto9xTemplates {
 
         fields.add(create(PaloAlto9xFields.PAN_GP_HOSTNAME, 35, STRING));
 
+
+        return toTemplate(fields);
+    }
+
+    public static PaloAltoMessageTemplate globalProtect913Template() {
+        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+
+        // Field 0 is FUTURE USE
+        fields.add(create(EventFields.EVENT_RECEIVED_TIME, 1, STRING));
+        fields.add(create(HostFields.HOST_ID, 2, STRING));
+        fields.add(create(EventFields.EVENT_LOG_NAME, 3, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
+
+        // Field 5 is FUTURE USE
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(HostFields.HOST_VIRTFW_ID, 7, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_EVENT_NAME, 8, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_TUNNEL_STAGE, 9, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_AUTH_METHOD, 10, STRING));
+        fields.add(create(NetworkFields.NETWORK_TUNNEL_TYPE, 11, STRING));
+        fields.add(create(UserFields.USER_ID, 12, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SOURCE_REGION, 13, STRING));
+        fields.add(create(SourceFields.SOURCE_HOSTNAME, 14, STRING));
+
+        fields.add(create(VendorFields.VENDOR_PUBLIC_IP, 15, STRING));
+        fields.add(create(VendorFields.VENDOR_PUBLIC_IPV6, 16, STRING));
+        fields.add(create(VendorFields.VENDOR_PRIVATE_IP, 17, STRING));
+        fields.add(create(VendorFields.VENDOR_PRIVATE_IPV6, 18, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_GP_HOSTID, 19, STRING));
+
+        // Field 20 is a repeat of Serial Number
+        fields.add(create(PaloAlto9xFields.PAN_GP_CLIENT_VERSION, 21, STRING));
+        fields.add(create(HostFields.HOST_TYPE, 22, STRING));
+        fields.add(create(HostFields.HOST_TYPE_VERSION, 23, STRING));
+        fields.add(create(EventFields.EVENT_REPEAT_COUNT, 24, LONG));
+
+        fields.add(create(PaloAlto9xFields.PAN_GP_REASON, 25, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_GP_ERROR, 26, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_GP_ERROR_EXTENDED, 27, STRING));
+        fields.add(create(VendorFields.VENDOR_EVENT_ACTION, 28, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_GP_LOCATION_NAME, 29, STRING));
+
+        fields.add(create(NetworkFields.NETWORK_TUNNEL_DURATION, 30, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_GP_CONNECT_METHOD, 31, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_GP_ERROR_CODE, 32, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_GP_HOSTNAME, 33, STRING));
+        fields.add(create(EventFields.EVENT_UID, 34, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_LOG_PANORAMA, 35, STRING));
 
         return toTemplate(fields);
     }

--- a/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodecTest.java
+++ b/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodecTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.verify;
 public class PaloAlto9xCodecTest {
     private static final String TEST_SOURCE = "Test Source";
     private static final DateTime TEST_DATE_TIME = DateTime.now();
-    private static final String TEST_RAW_MESSAGE = "Foo,Bar,Baz";
+    private static final String TEST_RAW_MESSAGE = "Foo,Bar,Baz,This,That,GLOBALPROTECT";
     private static final ImmutableList<String> TEST_FIELD_LIST = ImmutableList.of("Foo", "Bar", "Baz", "Three", "Four", "GLOBALPROTECT");
     private static final ImmutableMap<String,Object> TEST_FIELD_MAP = ImmutableMap.of("field_one", "value_one",
             "field_two", "value_two",
@@ -77,7 +77,20 @@ public class PaloAlto9xCodecTest {
     }
 
     @Test
-    public void decode_runsSuccessfully_whenGoodGlobalProtectInput() {
+    public void decode_runsSuccessfully_whenGoodGlobalProtect90Input() {
+        givenGoodInputRawMessage();
+        givenPaloMessageType("GLOBALPROTECT 9.0");
+        givenStoreFullMessage(false);
+        givenGoodFieldProducer();
+
+        whenDecodeIsCalled();
+
+        thenPaloParserCalledWithPaloMessageType(PaloAltoMessageType.GLOBAL_PROTECT_PRE_9_1_3);
+        thenOutputMessageContainsExpectedFields(false);
+    }
+
+    @Test
+    public void decode_runsSuccessfully_whenGoodGlobalProtect913Input() {
         givenGoodInputRawMessage();
         givenPaloMessageType("GLOBALPROTECT");
         givenStoreFullMessage(false);
@@ -85,7 +98,7 @@ public class PaloAlto9xCodecTest {
 
         whenDecodeIsCalled();
 
-        thenPaloParserCalledWithPaloMessageType(PaloAltoMessageType.GLOBAL_PROTECT);
+        thenPaloParserCalledWithPaloMessageType(PaloAltoMessageType.GLOBAL_PROTECT_9_1_3);
         thenOutputMessageContainsExpectedFields(false);
     }
 

--- a/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParserTest.java
+++ b/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParserTest.java
@@ -35,7 +35,8 @@ public class PaloAlto9xParserTest {
     // Mock Objects
     @Mock PaloAltoTypeParser mockConfigParser;
     @Mock PaloAltoTypeParser mockCorrelationParser;
-    @Mock PaloAltoTypeParser mockGlobalProtectParser;
+    @Mock PaloAltoTypeParser mockGlobalProtectPre913Parser;
+    @Mock PaloAltoTypeParser mockGlobalProtect913Parser;
     @Mock PaloAltoTypeParser mockHipParser;
     @Mock PaloAltoTypeParser mockSystemParser;
     @Mock PaloAltoTypeParser mockThreatParser;
@@ -51,7 +52,8 @@ public class PaloAlto9xParserTest {
     public void setUp() {
         cut = new PaloAlto9xParser(mockConfigParser,
                 mockCorrelationParser,
-                mockGlobalProtectParser,
+                mockGlobalProtectPre913Parser,
+                mockGlobalProtect913Parser,
                 mockHipParser,
                 mockSystemParser,
                 mockThreatParser,
@@ -84,14 +86,26 @@ public class PaloAlto9xParserTest {
     }
 
     @Test
-    public void parseFields_returnExpectedFieldMap_whenGlobalProtectMessageType() {
-        givenInputFieldType(PaloAltoMessageType.GLOBAL_PROTECT);
+    public void parseFields_returnExpectedFieldMap_whenPre913GlobalProtectMessageType() {
+        givenInputFieldType(PaloAltoMessageType.GLOBAL_PROTECT_PRE_9_1_3);
         givenGoodInputFields();
         givenGoodParsers();
 
         whenParseFieldsIsCalled();
 
-        thenGlobalProtectParserIsUsed();
+        thenPre913GlobalProtectParserIsUsed();
+        thenExpectedOutputIsReturned();
+    }
+
+    @Test
+    public void parseFields_returnExpectedFieldMap_when913GlobalProtectMessageType() {
+        givenInputFieldType(PaloAltoMessageType.GLOBAL_PROTECT_9_1_3);
+        givenGoodInputFields();
+        givenGoodParsers();
+
+        whenParseFieldsIsCalled();
+
+        then913GlobalProtectParserIsUsed();
         thenExpectedOutputIsReturned();
     }
 
@@ -167,7 +181,8 @@ public class PaloAlto9xParserTest {
     private void givenGoodParsers() {
         given(mockConfigParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
         given(mockCorrelationParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
-        given(mockGlobalProtectParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
+        given(mockGlobalProtectPre913Parser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
+        given(mockGlobalProtect913Parser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
         given(mockHipParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
         given(mockSystemParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
         given(mockThreatParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
@@ -184,7 +199,7 @@ public class PaloAlto9xParserTest {
         ArgumentCaptor<List<String>> fieldsCaptor = ArgumentCaptor.forClass(List.class);
         verify(mockConfigParser, times(1)).parseFields(fieldsCaptor.capture());
         verifyNoMoreInteractions(mockCorrelationParser);
-        verifyNoMoreInteractions(mockGlobalProtectParser);
+        verifyNoMoreInteractions(mockGlobalProtectPre913Parser);
         verifyNoMoreInteractions(mockHipParser);
         verifyNoMoreInteractions(mockSystemParser);
         verifyNoMoreInteractions(mockThreatParser);
@@ -195,16 +210,27 @@ public class PaloAlto9xParserTest {
         ArgumentCaptor<List<String>> fieldsCaptor = ArgumentCaptor.forClass(List.class);
         verify(mockCorrelationParser, times(1)).parseFields(fieldsCaptor.capture());
         verifyNoMoreInteractions(mockConfigParser);
-        verifyNoMoreInteractions(mockGlobalProtectParser);
+        verifyNoMoreInteractions(mockGlobalProtectPre913Parser);
         verifyNoMoreInteractions(mockHipParser);
         verifyNoMoreInteractions(mockSystemParser);
         verifyNoMoreInteractions(mockThreatParser);
         verifyNoMoreInteractions(mockTrafficParser);
     }
 
-    private void thenGlobalProtectParserIsUsed() {
+    private void thenPre913GlobalProtectParserIsUsed() {
         ArgumentCaptor<List<String>> fieldsCaptor = ArgumentCaptor.forClass(List.class);
-        verify(mockGlobalProtectParser, times(1)).parseFields(fieldsCaptor.capture());
+        verify(mockGlobalProtectPre913Parser, times(1)).parseFields(fieldsCaptor.capture());
+        verifyNoMoreInteractions(mockConfigParser);
+        verifyNoMoreInteractions(mockCorrelationParser);
+        verifyNoMoreInteractions(mockHipParser);
+        verifyNoMoreInteractions(mockSystemParser);
+        verifyNoMoreInteractions(mockThreatParser);
+        verifyNoMoreInteractions(mockTrafficParser);
+    }
+
+    private void then913GlobalProtectParserIsUsed() {
+        ArgumentCaptor<List<String>> fieldsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockGlobalProtect913Parser, times(1)).parseFields(fieldsCaptor.capture());
         verifyNoMoreInteractions(mockConfigParser);
         verifyNoMoreInteractions(mockCorrelationParser);
         verifyNoMoreInteractions(mockHipParser);
@@ -218,7 +244,7 @@ public class PaloAlto9xParserTest {
         verify(mockHipParser, times(1)).parseFields(fieldsCaptor.capture());
         verifyNoMoreInteractions(mockConfigParser);
         verifyNoMoreInteractions(mockCorrelationParser);
-        verifyNoMoreInteractions(mockGlobalProtectParser);
+        verifyNoMoreInteractions(mockGlobalProtectPre913Parser);
         verifyNoMoreInteractions(mockSystemParser);
         verifyNoMoreInteractions(mockThreatParser);
         verifyNoMoreInteractions(mockTrafficParser);
@@ -229,7 +255,7 @@ public class PaloAlto9xParserTest {
         verify(mockSystemParser, times(1)).parseFields(fieldsCaptor.capture());
         verifyNoMoreInteractions(mockConfigParser);
         verifyNoMoreInteractions(mockCorrelationParser);
-        verifyNoMoreInteractions(mockGlobalProtectParser);
+        verifyNoMoreInteractions(mockGlobalProtectPre913Parser);
         verifyNoMoreInteractions(mockHipParser);
         verifyNoMoreInteractions(mockThreatParser);
         verifyNoMoreInteractions(mockTrafficParser);
@@ -240,7 +266,7 @@ public class PaloAlto9xParserTest {
         verify(mockThreatParser, times(1)).parseFields(fieldsCaptor.capture());
         verifyNoMoreInteractions(mockConfigParser);
         verifyNoMoreInteractions(mockCorrelationParser);
-        verifyNoMoreInteractions(mockGlobalProtectParser);
+        verifyNoMoreInteractions(mockGlobalProtectPre913Parser);
         verifyNoMoreInteractions(mockHipParser);
         verifyNoMoreInteractions(mockSystemParser);
         verifyNoMoreInteractions(mockTrafficParser);
@@ -251,7 +277,7 @@ public class PaloAlto9xParserTest {
         verify(mockTrafficParser, times(1)).parseFields(fieldsCaptor.capture());
         verifyNoMoreInteractions(mockConfigParser);
         verifyNoMoreInteractions(mockCorrelationParser);
-        verifyNoMoreInteractions(mockGlobalProtectParser);
+        verifyNoMoreInteractions(mockGlobalProtectPre913Parser);
         verifyNoMoreInteractions(mockHipParser);
         verifyNoMoreInteractions(mockSystemParser);
         verifyNoMoreInteractions(mockThreatParser);
@@ -260,7 +286,7 @@ public class PaloAlto9xParserTest {
     private void thenNoParserUsed() {
         verifyNoMoreInteractions(mockConfigParser);
         verifyNoMoreInteractions(mockCorrelationParser);
-        verifyNoMoreInteractions(mockGlobalProtectParser);
+        verifyNoMoreInteractions(mockGlobalProtectPre913Parser);
         verifyNoMoreInteractions(mockHipParser);
         verifyNoMoreInteractions(mockSystemParser);
         verifyNoMoreInteractions(mockThreatParser);


### PR DESCRIPTION
Merge Palo Alto 9x plugin changes to 3.3 branch