### PR TITLE
Remove `--bail` flag from webpack build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git@github.com:Graylog2/graylog-plugin-integrations.git"
   },
   "scripts": {
-    "build": "webpack --bail",
+    "build": "webpack",
     "lint": "eslint --ext js,jsx src"
   },
   "keywords": [


### PR DESCRIPTION
Due to a recent `webpack-cli` upgrade, we need to remove the `--bail` flag from the build command, as it is not supported anymore and breaks the build.