### PR TITLE
Using mock okhttpclient 

### DIFF
--- a/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
@@ -54,6 +54,7 @@ public class SlackClientTest {
         assertThat(sent.url().toString()).isEqualTo("http://url.com/");
         assertThat(sent.method()).isEqualTo("POST");
         assertThat(sent.body()).isNotNull();
+        assertThat(sent.body().contentLength()).isEqualTo(76);
 
     }
 

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
@@ -15,8 +15,13 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.internal.bytebuddy.matcher.ElementMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import org.mockito.ArgumentCaptor;
 
@@ -41,17 +46,17 @@ public class SlackClientTest {
     public void send_sendsHttpRequestAsExpected_whenInputIsGood() throws Exception {
         SlackClient slackClient = new SlackClient(mockHttpClient);
         SlackMessage message = new SlackMessage("Henry Hühnchen(little chicken)");
-        slackClient.send(message,"http://url.com");
+        slackClient.send(message,"http://url.com/");
         
         ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
         verify(mockHttpClient, times(1)).newCall(requestCaptor.capture());
-        
-        assertThat(requestCaptor.getValue(), notNullValue());
+
+        assertThat(requestCaptor.getValue()).isNotNull();
         Request sent = requestCaptor.getValue();
-        assertThat(sent.url().toString(), is("http://url.com"));
-        assertThat(sent.method(), is("POST"));
-        assertThat(sent.body(), notNullValue());
-        assertThat(sent.body().contentLength(), is(Long.valueOf(message.length())));
+        assertThat(sent.url().toString()).isEqualTo("http://url.com/");
+        assertThat(sent.method()).isEqualTo("POST");
+        assertThat(sent.body()).isNotNull();
+
     }
 
     @Test(expected = TemporaryEventNotificationException.class)
@@ -65,7 +70,7 @@ public class SlackClientTest {
 
         SlackClient slackClient = new SlackClient(okHttpClient);
         SlackMessage message = new SlackMessage("Henry Hühnchen(little chicken)");
-        slackClient.send(message,"http://url.com");
+        slackClient.send(message,"http://url.com/");
     }
 
     @Test(expected = PermanentEventNotificationException.class)
@@ -74,7 +79,7 @@ public class SlackClientTest {
         final OkHttpClient okHttpClient = getMockHttpClient("{\"key\": \"val\"}",402);
         SlackClient slackClient = new SlackClient(okHttpClient);
         SlackMessage message = new SlackMessage("Henry Hühnchen(little chicken)");
-        slackClient.send(message,"http://url.com");
+        slackClient.send(message,"http://url.com/");
     }
 
 
@@ -85,7 +90,7 @@ public class SlackClientTest {
         final Call remoteCall = mock(Call.class);
 
         final Response response = new Response.Builder()
-                .request(new Request.Builder().url("http://url.com").build())
+                .request(new Request.Builder().url("http://url.com/").build())
                 .protocol(Protocol.HTTP_1_1)
                 .code(httpCode).message("").body(
                         ResponseBody.create(

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
@@ -48,7 +48,7 @@ public class SlackClientTest {
     }
 
     @Test(expected = TemporaryEventNotificationException.class)
-    public void send_fails_with_io_exception() throws Exception {
+    public void send_throwsTempNotifException_whenHttpClientThrowsIOException() throws Exception {
 
         final OkHttpClient okHttpClient = mock(OkHttpClient.class);
         final Call remoteCall = mock(Call.class);

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
@@ -8,6 +8,8 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.mockwebserver.MockWebServer;
+import org.graylog.events.notifications.PermanentEventNotificationException;
+import org.graylog.events.notifications.TemporaryEventNotificationException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,13 +40,37 @@ public class SlackClientTest {
     }
 
 
-
     @Test
     public void send_is_successful() throws Exception {
         SlackClient slackClient = new SlackClient(mockHttpClient);
         SlackMessage message = new SlackMessage("Henry Hühnchen(little chicken)");
         slackClient.send(message,"http://url.com");
     }
+
+    @Test(expected = TemporaryEventNotificationException.class)
+    public void send_fails_with_io_exception() throws Exception {
+
+        final OkHttpClient okHttpClient = mock(OkHttpClient.class);
+        final Call remoteCall = mock(Call.class);
+        when(remoteCall.execute()).thenThrow(new IOException("Request timeout"));
+        when(okHttpClient.newCall(any())).thenReturn(remoteCall);
+
+
+        SlackClient slackClient = new SlackClient(okHttpClient);
+        SlackMessage message = new SlackMessage("Henry Hühnchen(little chicken)");
+        slackClient.send(message,"http://url.com");
+    }
+
+    @Test(expected = PermanentEventNotificationException.class)
+    public void send_fails_with_badHook_url() throws Exception {
+
+        final OkHttpClient okHttpClient = getMockHttpClient("{\"key\": \"val\"}",402);
+        SlackClient slackClient = new SlackClient(okHttpClient);
+        SlackMessage message = new SlackMessage("Henry Hühnchen(little chicken)");
+        slackClient.send(message,"http://url.com");
+    }
+
+
 
     private static OkHttpClient getMockHttpClient(final String serializedBody,int httpCode) throws IOException {
         final OkHttpClient okHttpClient = mock(OkHttpClient.class);

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
@@ -16,8 +16,6 @@ import org.junit.Test;
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.internal.bytebuddy.matcher.ElementMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
@@ -62,7 +62,7 @@ public class SlackClientTest {
     }
 
     @Test(expected = PermanentEventNotificationException.class)
-    public void send_fails_with_badHook_url() throws Exception {
+    public void send_throwsPermNotifException_whenPostReturnsHttp402() throws Exception {
 
         final OkHttpClient okHttpClient = getMockHttpClient("{\"key\": \"val\"}",402);
         SlackClient slackClient = new SlackClient(okHttpClient);

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
@@ -31,11 +31,11 @@ public class SlackClientTest {
 
     @Before
     public void setUp() throws Exception {
-       mockHttpClient = getMockHttpClient("{\"key\": \"val\"}",200);
+       mockHttpClient = getMockHttpClient(200);
     }
 
     @After
-    public void tearDown() throws IOException {
+    public void tearDown() {
         mockHttpClient = null;
     }
 
@@ -75,7 +75,7 @@ public class SlackClientTest {
     @Test(expected = PermanentEventNotificationException.class)
     public void send_throwsPermNotifException_whenPostReturnsHttp402() throws Exception {
 
-        final OkHttpClient okHttpClient = getMockHttpClient("{\"key\": \"val\"}",402);
+        final OkHttpClient okHttpClient = getMockHttpClient(402);
         SlackClient slackClient = new SlackClient(okHttpClient);
         SlackMessage message = new SlackMessage("Henry Hühnchen(little chicken)");
         slackClient.send(message,"http://url.com/");
@@ -83,7 +83,7 @@ public class SlackClientTest {
 
 
 
-    private static OkHttpClient getMockHttpClient(final String serializedBody,int httpCode) throws IOException {
+    private static OkHttpClient getMockHttpClient(int httpCode) throws IOException {
         final OkHttpClient okHttpClient = mock(OkHttpClient.class);
 
         final Call remoteCall = mock(Call.class);
@@ -94,7 +94,7 @@ public class SlackClientTest {
                 .code(httpCode).message("").body(
                         ResponseBody.create(
                                 MediaType.parse("application/json"),
-                                serializedBody
+                                "{\"key\": \"val\"}"
                         ))
                 .build();
 

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
@@ -41,7 +41,7 @@ public class SlackClientTest {
 
 
     @Test
-    public void send_is_successful() throws Exception {
+    public void send_sendsHttpRequestAsExpected_whenInputIsGood() throws Exception {
         SlackClient slackClient = new SlackClient(mockHttpClient);
         SlackMessage message = new SlackMessage("Henry Hühnchen(little chicken)");
         slackClient.send(message,"http://url.com");

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
@@ -45,6 +45,16 @@ public class SlackClientTest {
         SlackClient slackClient = new SlackClient(mockHttpClient);
         SlackMessage message = new SlackMessage("Henry Hühnchen(little chicken)");
         slackClient.send(message,"http://url.com");
+        
+        ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+        verify(mockHttpClient, times(1)).newCall(requestCaptor.capture());
+        
+        assertThat(requestCaptor.getValue(), notNullValue());
+        Request sent = requestCaptor.getValue();
+        assertThat(sent.url().toString(), is("http://url.com"));
+        assertThat(sent.method(), is("POST"));
+        assertThat(sent.body(), notNullValue());
+        assertThat(sent.body().contentLength(), is(Long.valueOf(message.length())));
     }
 
     @Test(expected = TemporaryEventNotificationException.class)

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import org.mockito.ArgumentCaptor;
 
 
 public class SlackClientTest {

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
@@ -1,6 +1,5 @@
 package org.graylog.integrations.notifications.types;
 
-import com.github.joschi.jadconfig.util.Duration;
 import okhttp3.Call;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -9,24 +8,14 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.mockwebserver.MockWebServer;
-import org.graylog.events.notifications.PermanentEventNotificationException;
-import org.graylog2.shared.bindings.providers.OkHttpClientProvider;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
 
 import java.io.IOException;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackClientTest.java
@@ -7,7 +7,6 @@ import okhttp3.Protocol;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import okhttp3.mockwebserver.MockWebServer;
 import org.graylog.events.notifications.PermanentEventNotificationException;
 import org.graylog.events.notifications.TemporaryEventNotificationException;
 import org.junit.After;
@@ -22,20 +21,17 @@ import static org.mockito.Mockito.when;
 
 
 public class SlackClientTest {
-
-    private final MockWebServer server = new MockWebServer();
+    
     private OkHttpClient mockHttpClient;
 
 
     @Before
     public void setUp() throws Exception {
        mockHttpClient = getMockHttpClient("{\"key\": \"val\"}",200);
-       server.start();
     }
 
     @After
     public void tearDown() throws IOException {
-        server.shutdown();
         mockHttpClient = null;
     }
 


### PR DESCRIPTION
- SlackClientTest uses `mock` httpClient and the imports have been optimized.

![slackclienttest_junit](https://user-images.githubusercontent.com/6947168/97624464-2007dc00-19f5-11eb-9b49-e6f53914b814.png)
