### PR TITLE
Add notification details page for PagerDuty

### DIFF
--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -1,11 +1,12 @@
 import 'webpack-entry';
 
-import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
+import {PluginManifest, PluginStore} from 'graylog-web-plugin/plugin';
 
 import Routes from 'aws/common/Routes';
 
 import AWSInputConfiguration from './aws/AWSInputConfiguration';
 import AWSCloudWatchApp from './aws/cloudwatch/CloudWatchApp';
+import PagerDutyNotificationDetails from './pager-duty/PagerDutyNotificationDetails';
 import PagerDutyNotificationForm from './pager-duty/PagerDutyNotificationForm';
 import PagerDutyNotificationSummary from './pager-duty/PagerDutyNotificationSummary';
 import SlackNotificationForm from './event-notifications/event-notification-types/SlackNotificationForm';
@@ -29,6 +30,7 @@ const manifest = new PluginManifest(packageJson, {
       displayName: 'PagerDuty Notification [Official]',
       formComponent: PagerDutyNotificationForm,
       summaryComponent: PagerDutyNotificationSummary,
+      detailsComponent: PagerDutyNotificationDetails,
       defaultConfig: PagerDutyNotificationForm.defaultConfig,
     },
     {

--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -1,6 +1,6 @@
 import 'webpack-entry';
 
-import {PluginManifest, PluginStore} from 'graylog-web-plugin/plugin';
+import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 
 import Routes from 'aws/common/Routes';
 

--- a/src/web/pager-duty/PagerDutyNotificationDetails.jsx
+++ b/src/web/pager-duty/PagerDutyNotificationDetails.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-import {ReadOnlyFormGroup} from 'components/common';
+import { ReadOnlyFormGroup } from 'components/common';
 
 const PagerDutyNotificationDetails = ({ notification }) => {
   return (

--- a/src/web/pager-duty/PagerDutyNotificationDetails.jsx
+++ b/src/web/pager-duty/PagerDutyNotificationDetails.jsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+import {ReadOnlyFormGroup} from 'components/common';
+
+const PagerDutyNotificationDetails = ({ notification }) => {
+    return (
+        <>
+            <ReadOnlyFormGroup label="Routing Key" value={notification?.config?.routing_key} />
+            <ReadOnlyFormGroup label="Custom Incident" value={notification?.config?.custom_incident ? 'Yes' : 'No'} />
+            <ReadOnlyFormGroup label="Key Prefix" value={notification?.config?.key_prefix} />
+            <ReadOnlyFormGroup label="Client Name" value={notification?.config?.client_name} />
+            <ReadOnlyFormGroup label="Client URL" value={notification?.config?.client_url} />
+        </>
+    );
+};
+
+PagerDutyNotificationDetails.propTypes = {
+    notification: PropTypes.shape({
+        config: PropTypes.shape({
+            routing_key: PropTypes.string,
+            custom_incident: PropTypes.bool,
+            key_prefix: PropTypes.string,
+            client_name: PropTypes.string,
+            client_url: PropTypes.string,
+        }).isRequired,
+    }).isRequired,
+};
+
+export default PagerDutyNotificationDetails;

--- a/src/web/pager-duty/PagerDutyNotificationDetails.jsx
+++ b/src/web/pager-duty/PagerDutyNotificationDetails.jsx
@@ -6,11 +6,11 @@ import {ReadOnlyFormGroup} from 'components/common';
 const PagerDutyNotificationDetails = ({ notification }) => {
     return (
         <>
-            <ReadOnlyFormGroup label="Routing Key" value={notification?.config?.routing_key} />
-            <ReadOnlyFormGroup label="Custom Incident" value={notification?.config?.custom_incident ? 'Yes' : 'No'} />
-            <ReadOnlyFormGroup label="Key Prefix" value={notification?.config?.key_prefix} />
-            <ReadOnlyFormGroup label="Client Name" value={notification?.config?.client_name} />
-            <ReadOnlyFormGroup label="Client URL" value={notification?.config?.client_url} />
+            <ReadOnlyFormGroup label="Routing Key" value={notification.config?.routing_key} />
+            <ReadOnlyFormGroup label="Custom Incident" value={notification.config?.custom_incident ? 'Yes' : 'No'} />
+            <ReadOnlyFormGroup label="Key Prefix" value={notification.config?.key_prefix} />
+            <ReadOnlyFormGroup label="Client Name" value={notification.config?.client_name} />
+            <ReadOnlyFormGroup label="Client URL" value={notification.config?.client_url} />
         </>
     );
 };

--- a/src/web/pager-duty/PagerDutyNotificationDetails.jsx
+++ b/src/web/pager-duty/PagerDutyNotificationDetails.jsx
@@ -4,27 +4,27 @@ import PropTypes from 'prop-types';
 import {ReadOnlyFormGroup} from 'components/common';
 
 const PagerDutyNotificationDetails = ({ notification }) => {
-    return (
-        <>
-            <ReadOnlyFormGroup label="Routing Key" value={notification.config?.routing_key} />
-            <ReadOnlyFormGroup label="Custom Incident" value={notification.config?.custom_incident ? 'Yes' : 'No'} />
-            <ReadOnlyFormGroup label="Key Prefix" value={notification.config?.key_prefix} />
-            <ReadOnlyFormGroup label="Client Name" value={notification.config?.client_name} />
-            <ReadOnlyFormGroup label="Client URL" value={notification.config?.client_url} />
-        </>
-    );
+  return (
+    <>
+      <ReadOnlyFormGroup label="Routing Key" value={notification.config?.routing_key} />
+      <ReadOnlyFormGroup label="Custom Incident" value={notification.config?.custom_incident ? 'Yes' : 'No'} />
+      <ReadOnlyFormGroup label="Key Prefix" value={notification.config?.key_prefix} />
+      <ReadOnlyFormGroup label="Client Name" value={notification.config?.client_name} />
+      <ReadOnlyFormGroup label="Client URL" value={notification.config?.client_url} />
+    </>
+  );
 };
 
 PagerDutyNotificationDetails.propTypes = {
-    notification: PropTypes.shape({
-        config: PropTypes.shape({
-            routing_key: PropTypes.string,
-            custom_incident: PropTypes.bool,
-            key_prefix: PropTypes.string,
-            client_name: PropTypes.string,
-            client_url: PropTypes.string,
-        }).isRequired,
+  notification: PropTypes.shape({
+    config: PropTypes.shape({
+      routing_key: PropTypes.string,
+      custom_incident: PropTypes.bool,
+      key_prefix: PropTypes.string,
+      client_name: PropTypes.string,
+      client_url: PropTypes.string,
     }).isRequired,
+  }).isRequired,
 };
 
 export default PagerDutyNotificationDetails;


### PR DESCRIPTION
Testing in smd-dev revealed that the details page was missing for PagerDuty notifications.  This PR adds the details page.

Tested locally with existing PagerDuty notification.  Screen shot:
![Screen Shot 2020-11-03 at 2 29 15 PM](https://user-images.githubusercontent.com/6466251/98032357-e57db500-1de1-11eb-926f-2026a853db6e.png)
