### PR TITLE
Add Details page for PagerDuty Notifications

### DIFF
--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -6,6 +6,7 @@ import Routes from 'aws/common/Routes';
 
 import AWSInputConfiguration from './aws/AWSInputConfiguration';
 import AWSCloudWatchApp from './aws/cloudwatch/CloudWatchApp';
+import PagerDutyNotificationDetails from "./pager-duty/PagerDutyNotificationDetails";
 import PagerDutyNotificationForm from './pager-duty/PagerDutyNotificationForm';
 import PagerDutyNotificationSummary from './pager-duty/PagerDutyNotificationSummary';
 import SlackNotificationDetails from './event-notifications/event-notification-details/SlackNotificationDetails';
@@ -30,6 +31,7 @@ const manifest = new PluginManifest(packageJson, {
       displayName: 'PagerDuty Notification [Official]',
       formComponent: PagerDutyNotificationForm,
       summaryComponent: PagerDutyNotificationSummary,
+      detailsComponent: PagerDutyNotificationDetails,
       defaultConfig: PagerDutyNotificationForm.defaultConfig,
     },
     {

--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -6,7 +6,7 @@ import Routes from 'aws/common/Routes';
 
 import AWSInputConfiguration from './aws/AWSInputConfiguration';
 import AWSCloudWatchApp from './aws/cloudwatch/CloudWatchApp';
-import PagerDutyNotificationDetails from "./pager-duty/PagerDutyNotificationDetails";
+import PagerDutyNotificationDetails from './pager-duty/PagerDutyNotificationDetails';
 import PagerDutyNotificationForm from './pager-duty/PagerDutyNotificationForm';
 import PagerDutyNotificationSummary from './pager-duty/PagerDutyNotificationSummary';
 import SlackNotificationDetails from './event-notifications/event-notification-details/SlackNotificationDetails';

--- a/src/web/pager-duty/PagerDutyNotificationDetails.jsx
+++ b/src/web/pager-duty/PagerDutyNotificationDetails.jsx
@@ -4,27 +4,27 @@ import PropTypes from 'prop-types';
 import { ReadOnlyFormGroup } from 'components/common';
 
 const PagerDutyNotificationDetails = ({ notification }) => {
-    return (
-        <>
-            <ReadOnlyFormGroup label="Routing Key" value={notification.config?.routing_key} />
-            <ReadOnlyFormGroup label="Custom Incident" value={notification.config?.custom_incident} />
-            <ReadOnlyFormGroup label="Key Prefix" value={notification.config?.key_prefix} />
-            <ReadOnlyFormGroup label="Client Name" value={notification.config?.client_name} />
-            <ReadOnlyFormGroup label="Client URL" value={notification.config?.client_url} />
-        </>
-    );
+  return (
+    <>
+      <ReadOnlyFormGroup label="Routing Key" value={notification.config?.routing_key} />
+      <ReadOnlyFormGroup label="Custom Incident" value={notification.config?.custom_incident} />
+      <ReadOnlyFormGroup label="Key Prefix" value={notification.config?.key_prefix} />
+      <ReadOnlyFormGroup label="Client Name" value={notification.config?.client_name} />
+      <ReadOnlyFormGroup label="Client URL" value={notification.config?.client_url} />
+    </>
+  );
 };
 
 PagerDutyNotificationDetails.propTypes = {
-    notification: PropTypes.shape({
-        config: PropTypes.shape({
-            routing_key: PropTypes.string,
-            custom_incident: PropTypes.bool,
-            key_prefix: PropTypes.string,
-            client_name: PropTypes.string,
-            client_url: PropTypes.string,
-        }).isRequired,
+  notification: PropTypes.shape({
+    config: PropTypes.shape({
+      routing_key: PropTypes.string,
+      custom_incident: PropTypes.bool,
+      key_prefix: PropTypes.string,
+      client_name: PropTypes.string,
+      client_url: PropTypes.string,
     }).isRequired,
+  }).isRequired,
 };
 
 export default PagerDutyNotificationDetails;

--- a/src/web/pager-duty/PagerDutyNotificationDetails.jsx
+++ b/src/web/pager-duty/PagerDutyNotificationDetails.jsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+import { ReadOnlyFormGroup } from 'components/common';
+
+const PagerDutyNotificationDetails = ({ notification }) => {
+    return (
+        <>
+            <ReadOnlyFormGroup label="Routing Key" value={notification.config?.routing_key} />
+            <ReadOnlyFormGroup label="Custom Incident" value={notification.config?.custom_incident} />
+            <ReadOnlyFormGroup label="Key Prefix" value={notification.config?.key_prefix} />
+            <ReadOnlyFormGroup label="Client Name" value={notification.config?.client_name} />
+            <ReadOnlyFormGroup label="Client URL" value={notification.config?.client_url} />
+        </>
+    );
+};
+
+PagerDutyNotificationDetails.propTypes = {
+    notification: PropTypes.shape({
+        config: PropTypes.shape({
+            routing_key: PropTypes.string,
+            custom_incident: PropTypes.bool,
+            key_prefix: PropTypes.string,
+            client_name: PropTypes.string,
+            client_url: PropTypes.string,
+        }).isRequired,
+    }).isRequired,
+};
+
+export default PagerDutyNotificationDetails;


### PR DESCRIPTION
We discovered in smd-dev that PagerDuty notifications did not have a Details page.  This PR adds the Details page.

Tested locally:
![Screen Shot 2020-11-04 at 10 11 29 AM](https://user-images.githubusercontent.com/6466251/98128635-216a5600-1e86-11eb-99df-1d559dba12cc.png)

Verified locally with `yarn lint` that no eslint errors exist.