### PR TITLE
Palo Alto input updates to support PANOS v10 schemas

### DIFF
--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTypeParser.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTypeParser.java
@@ -18,10 +18,13 @@ package org.graylog.integrations.inputs.paloalto;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Map;
 
 public class PaloAltoTypeParser {
 
@@ -37,7 +40,7 @@ public class PaloAltoTypeParser {
     }
 
     public ImmutableMap<String, Object> parseFields(List<String> fields) {
-        ImmutableMap.Builder<String, Object> x = new ImmutableMap.Builder<>();
+        Map<String, Object> fieldMap = Maps.newHashMap();
 
         for (PaloAltoFieldTemplate field : messageTemplate.getFields()) {
             String rawValue = null;
@@ -83,9 +86,25 @@ public class PaloAltoTypeParser {
                     throw new RuntimeException("Unhandled PAN mapping field type [" + field.fieldType() + "].");
             }
 
-            x.put(field.field(), value);
+            // Handling of duplicate keys
+            if (fieldMap.containsKey(field.field())) {
+                if (rawValue.equals("") || value.equals(fieldMap.get(field.field()))) {
+                    // Same value, do nothing
+                    continue;
+                } else if (fieldMap.get(field.field()) instanceof List) {
+                    List valueList = (List) fieldMap.get(field.field());
+                    valueList.add(value);
+                    value = valueList;
+                } else {
+                    List valueList = Lists.newArrayList();
+                    valueList.add(fieldMap.get(field.field()));
+                    valueList.add(value);
+                    value = valueList;
+                }
+            }
+            fieldMap.put(field.field(), value);
         }
 
-        return x.build();
+        return ImmutableMap.copyOf(fieldMap);
     }
 }

--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTypeParser.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTypeParser.java
@@ -88,7 +88,7 @@ public class PaloAltoTypeParser {
 
             // Handling of duplicate keys
             if (fieldMap.containsKey(field.field())) {
-                if (rawValue.equals("") || value.equals(fieldMap.get(field.field()))) {
+                if (Strings.isNullOrEmpty(rawValue) || value.equals(fieldMap.get(field.field()))) {
                     // Same value, do nothing
                     continue;
                 } else if (fieldMap.get(field.field()) instanceof List) {

--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTypeParser.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTypeParser.java
@@ -88,7 +88,7 @@ public class PaloAltoTypeParser {
 
             // Handling of duplicate keys
             if (fieldMap.containsKey(field.field())) {
-                if (Strings.isNullOrEmpty(rawValue) || value.equals(fieldMap.get(field.field()))) {
+                if (Strings.isNullOrEmpty(rawValue.trim()) || value.equals(fieldMap.get(field.field()))) {
                     // Same value, do nothing
                     continue;
                 } else if (fieldMap.get(field.field()) instanceof List) {

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xFields.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xFields.java
@@ -20,21 +20,30 @@ public class PaloAlto9xFields {
     public static final String PAN_AFTER_CHANGE_DETAIL = "pan_after_change_detail";
     public static final String PAN_ALERT_DIRECTION = "pan_alert_direction";
     public static final String PAN_ASSOC_ID = "pan_assoc_id";
+    public static final String PAN_ATTEMPTED_GATEWAYS = "pan_attempted_gateways";
     public static final String PAN_AUTH_METHOD = "pan_auth_method";
     public static final String PAN_BEFORE_CHANGE_DETAIL = "pan_before_change_detail";
 
     public static final String PAN_CLOUD_HOSTNAME = "pan_cloud_hostname";
+    public static final String PAN_DESTINATION_PROFILE = "pan_destination_profile";
     public static final String PAN_DEV_GROUP_LEVEL_1 = "pan_dev_group_level_1";
     public static final String PAN_DEV_GROUP_LEVEL_2 = "pan_dev_group_level_2";
     public static final String PAN_DEV_GROUP_LEVEL_3 = "pan_dev_group_level_3";
     public static final String PAN_DEV_GROUP_LEVEL_4 = "pan_dev_group_level_4";
 
+    public static final String PAN_DOMAIN_EDL = "pan_domain_edl";
+    public static final String PAN_DST_DAG = "pan_dst_dag";
+    public static final String PAN_DST_EDL = "pan_dst_edl";
+
     public static final String PAN_DYNUSERGROUP_NAME = "pan_dynusergroup_name";
     public static final String PAN_EVENT_NAME = "pan_event_name";
     public static final String PAN_EVENT_OBJECT = "pan_event_object";
+    public static final String PAN_EVENT_JUSTIFICATION = "pan_event_justification";
     public static final String PAN_EVIDENCE = "pan_evidence";
     public static final String PAN_FLAGS = "pan_flags";
 
+    public static final String PAN_GATEWAY = "pan_gateway";
+    public static final String PAN_GATEWAY_PRIORITY = "pan_gateway_priority";
     public static final String PAN_GP_CLIENT_VERSION = "pan_gp_client_version";
     public static final String PAN_GP_CONNECT_METHOD = "pan_gp_connect_method";
     public static final String PAN_GP_ERROR = "pan_gp_error";
@@ -45,9 +54,12 @@ public class PaloAlto9xFields {
     public static final String PAN_GP_HOSTNAME = "pan_gp_hostname";
     public static final String PAN_GP_LOCATION_NAME = "pan_gp_location_name";
     public static final String PAN_GP_REASON = "pan_gp_reason";
+    public static final String PAN_HIGH_RES_TIME = "pan_high_res_time";
     public static final String PAN_HIP = "pan_hip";
 
     public static final String PAN_HIP_TYPE = "pan_hip_type";
+    public static final String PAN_HOST_ID = "pan_host_id";
+    public static final String PAN_HOST_SN = "pan_host_sn";
     public static final String PAN_HTTP2 = "pan_http2";
     public static final String PAN_LINK_CHANGES = "pan_link_changes";
     public static final String PAN_LINK_SWITCHES = "pan_link_switches";
@@ -57,11 +69,14 @@ public class PaloAlto9xFields {
     public static final String PAN_LOG_SUBTYPE = "pan_log_subtype";
     public static final String PAN_MODULE = "pan_module";
     public static final String PAN_MONITOR_TAG = "pan_monitor_tag";
+    public static final String PAN_NSDSAI_SD = "pan_nsdsai_sd";
+    public static final String PAN_NSDSAI_SST = "pan_nsdsai_sst";
     public static final String PAN_OBJECT_ID = "pan_object_id";
 
     public static final String PAN_OBJECTNAME = "pan_objectname";
     public static final String PAN_PARENT_SESSION_ID = "pan_parent_session_id";
     public static final String PAN_PARENT_START_TIME = "pan_parent_start_time";
+    public static final String PAN_PARTIAL_HASH = "pan_partial_hash";
     public static final String PAN_PCAP_ID = "pan_pcap_id";
     public static final String PAN_PPID = "pan_ppid";
 
@@ -74,9 +89,14 @@ public class PaloAlto9xFields {
     public static final String PAN_SDWAN_DEVICE_TYPE = "pan_sdwan_device_type";
     public static final String PAN_SDWAN_POLICY_ID = "pan_sdwan_policyid";
     public static final String PAN_SDWAN_SITE_NAME = "pan_sdwan_site_name";
+    public static final String PAN_SELECTION_TYPE = "pan_selection_type";
     public static final String PAN_SESSION_END_REASON = "pan_session_end_reason";
+    public static final String PAN_SESSION_OWNER = "pan_session_owner";
+    public static final String PAN_SOURCE_PROFILE = "pan_source_profile";
     public static final String PAN_SOURCE_REGION = "pan_source_region";
 
+    public static final String PAN_SRC_DAG = "pan_src_dag";
+    public static final String PAN_SRC_EDL = "pan_src_edl";
     public static final String PAN_TUNNEL_ID = "pan_tunnel_id";
     public static final String PAN_TUNNEL_STAGE = "pan_tunnel_stage";
     public static final String PAN_URL_INDEX = "pan_url_index";

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xInput.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xInput.java
@@ -35,7 +35,7 @@ import javax.inject.Inject;
 public class PaloAlto9xInput extends MessageInput {
     private static final Logger LOG = LoggerFactory.getLogger(PaloAlto9xInput.class);
 
-    public static final String NAME = "Palo Alto Networks TCP (PAN-OS v9.x)";
+    public static final String NAME = "Palo Alto Networks TCP (PAN-OS v9+)";
 
     @Inject
     public PaloAlto9xInput(@Assisted Configuration configuration,

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
@@ -169,7 +169,7 @@ public class PaloAlto9xTemplates {
 
         // Field 0 is FUTURE USE
         fields.add(create(EventFields.EVENT_RECEIVED_TIME, 1, STRING));
-        fields.add(create(HostFields.HOST_ID, 2, STRING));
+        fields.add(create(HostFields.HOST_ID, 2, STRING)); // TODO: Used twice
         fields.add(create(EventFields.EVENT_UID, 3, STRING));
         fields.add(create(PaloAlto9xFields.PAN_LOG_PANORAMA, 4, STRING));
 
@@ -193,7 +193,7 @@ public class PaloAlto9xTemplates {
 
         fields.add(create(VendorFields.VENDOR_PRIVATE_IPV6, 20, STRING));
         fields.add(create(PaloAlto9xFields.PAN_GP_HOSTID, 21, STRING));
-        fields.add(create(HostFields.HOST_ID, 22, STRING));
+        // fields.add(create(HostFields.HOST_ID, 22, STRING)); // TODO: Used twice
         fields.add(create(PaloAlto9xFields.PAN_GP_CLIENT_VERSION, 23, STRING));
         fields.add(create(HostFields.HOST_TYPE, 24, STRING));
 

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
@@ -21,6 +21,7 @@ import org.graylog.integrations.inputs.paloalto.PaloAltoFieldTemplate;
 import org.graylog.integrations.inputs.paloalto.PaloAltoMessageTemplate;
 import org.graylog.schema.AlertFields;
 import org.graylog.schema.ApplicationFields;
+import org.graylog.schema.ContainerFields;
 import org.graylog.schema.DestinationFields;
 import org.graylog.schema.EmailFields;
 import org.graylog.schema.EventFields;
@@ -28,6 +29,8 @@ import org.graylog.schema.FileFields;
 import org.graylog.schema.HostFields;
 import org.graylog.schema.HttpFields;
 import org.graylog.schema.NetworkFields;
+import org.graylog.schema.PolicyFields;
+import org.graylog.schema.RuleFields;
 import org.graylog.schema.SessionFields;
 import org.graylog.schema.SourceFields;
 import org.graylog.schema.ThreatFields;
@@ -96,7 +99,7 @@ public class PaloAlto9xTemplates {
         // Field 5 is FUTURE USE
         fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
         fields.add(create(SourceFields.SOURCE_IP, 7, STRING));
-        fields.add(create(SourceFields.SOURCE_USER, 8, STRING));
+        fields.add(create(UserFields.USER_NAME, 8, STRING));
         fields.add(create(HostFields.HOST_VIRTFW_ID, 9, STRING));
 
         fields.add(create(ThreatFields.THREAT_CATEGORY, 10, STRING));
@@ -128,12 +131,12 @@ public class PaloAlto9xTemplates {
 
         // Field 5 is FUTURE USE
         fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
-        fields.add(create(SourceFields.SOURCE_USER, 7, STRING));
+        fields.add(create(UserFields.USER_NAME, 7, STRING));
         fields.add(create(HostFields.HOST_VIRTFW_ID, 8, STRING));
-        fields.add(create(EventFields.EVENT_OBSERVER_HOSTNAME, 9, STRING));
+        fields.add(create(HostFields.HOST_HOSTNAME, 9, STRING));
 
         fields.add(create(HostFields.HOST_TYPE, 10, STRING));
-        fields.add(create(SourceFields.SOURCE_IP, 11, STRING));
+        fields.add(create(HostFields.HOST_IP, 11, STRING));
         fields.add(create(PaloAlto9xFields.PAN_HIP, 12, STRING));
         fields.add(create(EventFields.EVENT_REPEAT_COUNT, 13, LONG));
         fields.add(create(PaloAlto9xFields.PAN_HIP_TYPE, 14, STRING));
@@ -148,12 +151,15 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_3, 21, LONG));
         fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4, 22, LONG));
         fields.add(create(HostFields.HOST_VIRTFW_HOSTNAME, 23, STRING));
-        fields.add(create(HostFields.HOST_HOSTNAME, 24, STRING));
+        fields.add(create(EventFields.EVENT_OBSERVER_HOSTNAME, 24, STRING));
 
         fields.add(create(HostFields.HOST_VIRTFW_UID, 25, STRING));
-        fields.add(create(SourceFields.SOURCE_IPV6, 26, STRING));
+        fields.add(create(HostFields.HOST_IPV6, 26, STRING));
         fields.add(create(PaloAlto9xFields.PAN_GP_HOSTID, 27, STRING));
         fields.add(create(HostFields.HOST_ID, 28, STRING));
+        fields.add(create(SourceFields.SOURCE_MAC, 29, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_HIGH_RES_TIME, 30, STRING));
 
         return toTemplate(fields);
     }
@@ -163,7 +169,7 @@ public class PaloAlto9xTemplates {
 
         // Field 0 is FUTURE USE
         fields.add(create(EventFields.EVENT_RECEIVED_TIME, 1, STRING));
-        fields.add(create(HostFields.HOST_ID, 2, STRING));  // TODO: Used twice
+        fields.add(create(HostFields.HOST_ID, 2, STRING));
         fields.add(create(EventFields.EVENT_UID, 3, STRING));
         fields.add(create(PaloAlto9xFields.PAN_LOG_PANORAMA, 4, STRING));
 
@@ -187,7 +193,7 @@ public class PaloAlto9xTemplates {
 
         fields.add(create(VendorFields.VENDOR_PRIVATE_IPV6, 20, STRING));
         fields.add(create(PaloAlto9xFields.PAN_GP_HOSTID, 21, STRING));
-        // fields.add(create(HostFields.HOST_ID, 22, STRING)); // TODO: Used twice
+        fields.add(create(HostFields.HOST_ID, 22, STRING));
         fields.add(create(PaloAlto9xFields.PAN_GP_CLIENT_VERSION, 23, STRING));
         fields.add(create(HostFields.HOST_TYPE, 24, STRING));
 
@@ -226,7 +232,7 @@ public class PaloAlto9xTemplates {
 
         fields.add(create(PaloAlto9xFields.PAN_AUTH_METHOD, 10, STRING));
         fields.add(create(NetworkFields.NETWORK_TUNNEL_TYPE, 11, STRING));
-        fields.add(create(UserFields.USER_ID, 12, STRING));
+        fields.add(create(UserFields.USER_NAME, 12, STRING));
         fields.add(create(PaloAlto9xFields.PAN_SOURCE_REGION, 13, STRING));
         fields.add(create(SourceFields.SOURCE_HOSTNAME, 14, STRING));
 
@@ -236,25 +242,31 @@ public class PaloAlto9xTemplates {
         fields.add(create(VendorFields.VENDOR_PRIVATE_IPV6, 18, STRING));
         fields.add(create(PaloAlto9xFields.PAN_GP_HOSTID, 19, STRING));
 
-        // Field 20 is a repeat of Serial Number
+        fields.add(create(SourceFields.SOURCE_ID, 20, STRING));
         fields.add(create(PaloAlto9xFields.PAN_GP_CLIENT_VERSION, 21, STRING));
-        fields.add(create(HostFields.HOST_TYPE, 22, STRING));
-        fields.add(create(HostFields.HOST_TYPE_VERSION, 23, STRING));
+        fields.add(create(SourceFields.SOURCE_OS_NAME, 22, STRING));
+        fields.add(create(SourceFields.SOURCE_OS_VERSION, 23, STRING));
         fields.add(create(EventFields.EVENT_REPEAT_COUNT, 24, LONG));
 
         fields.add(create(PaloAlto9xFields.PAN_GP_REASON, 25, STRING));
-        fields.add(create(PaloAlto9xFields.PAN_GP_ERROR, 26, STRING));
+        fields.add(create(EventFields.EVENT_ERROR_DESCRIPTION, 26, STRING));
         fields.add(create(PaloAlto9xFields.PAN_GP_ERROR_EXTENDED, 27, STRING));
-        fields.add(create(VendorFields.VENDOR_EVENT_ACTION, 28, STRING));
+        fields.add(create(VendorFields.VENDOR_EVENT_OUTCOME, 28, STRING));
         fields.add(create(PaloAlto9xFields.PAN_GP_LOCATION_NAME, 29, STRING));
 
         fields.add(create(NetworkFields.NETWORK_TUNNEL_DURATION, 30, LONG));
         fields.add(create(PaloAlto9xFields.PAN_GP_CONNECT_METHOD, 31, STRING));
-        fields.add(create(PaloAlto9xFields.PAN_GP_ERROR_CODE, 32, LONG));
-        fields.add(create(PaloAlto9xFields.PAN_GP_HOSTNAME, 33, STRING));
+        fields.add(create(EventFields.EVENT_ERROR_CODE, 32, LONG));
+        fields.add(create(DestinationFields.DESTINATION_HOSTNAME, 33, STRING));
         fields.add(create(EventFields.EVENT_UID, 34, STRING));
 
         fields.add(create(PaloAlto9xFields.PAN_LOG_PANORAMA, 35, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SELECTION_TYPE, 36, STRING));
+        fields.add(create(ApplicationFields.APPLICATION_RESPONSE_TIME, 37, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_GATEWAY_PRIORITY, 38, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_ATTEMPTED_GATEWAYS, 39, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_GATEWAY, 40, STRING));
 
         return toTemplate(fields);
     }
@@ -289,6 +301,7 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4, 20, LONG));
         fields.add(create(HostFields.HOST_VIRTFW_HOSTNAME, 21, STRING));
         fields.add(create(HostFields.HOST_HOSTNAME, 22, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_HIGH_RES_TIME, 23, STRING));
 
         return toTemplate(fields);
     }
@@ -298,7 +311,7 @@ public class PaloAlto9xTemplates {
 
         // Field 0 is FUTURE USE
         fields.add(create(EventFields.EVENT_RECEIVED_TIME, 1, STRING));
-        fields.add(create(HostFields.HOST_ID, 2, STRING));
+        fields.add(create(EventFields.EVENT_OBSERVER_ID, 2, STRING));
         fields.add(create(EventFields.EVENT_LOG_NAME, 3, STRING));
         fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
 
@@ -309,9 +322,9 @@ public class PaloAlto9xTemplates {
         fields.add(create(SourceFields.SOURCE_NAT_IP, 9, STRING));
 
         fields.add(create(DestinationFields.DESTINATION_NAT_IP, 10, STRING));
-        fields.add(create("rule_name", 11, STRING)); // TODO: Need constant
-        fields.add(create(SourceFields.SOURCE_USER, 12, STRING));
-        fields.add(create("target_user", 13, STRING)); // TODO: Need constant
+        fields.add(create(RuleFields.RULE_NAME, 11, STRING));
+        fields.add(create(SourceFields.SOURCE_USER_NAME, 12, STRING));
+        fields.add(create(DestinationFields.DESTINATION_USER_NAME, 13, STRING));
         fields.add(create(ApplicationFields.APPLICATION_NAME, 14, STRING));
 
         fields.add(create(HostFields.HOST_VIRTFW_ID, 15, STRING));
@@ -330,12 +343,12 @@ public class PaloAlto9xTemplates {
         fields.add(create(SourceFields.SOURCE_NAT_PORT, 26, LONG));
         fields.add(create(DestinationFields.DESTINATION_NAT_PORT, 27, LONG));
         fields.add(create(PaloAlto9xFields.PAN_FLAGS, 28, STRING));
-        fields.add(create(NetworkFields.NETWORK_PROTOCOL, 29, STRING));
+        fields.add(create(NetworkFields.NETWORK_TRANSPORT, 29, STRING));
 
         fields.add(create(VendorFields.VENDOR_EVENT_ACTION, 30, STRING));
         fields.add(create(AlertFields.ALERT_INDICATOR, 31, STRING));
-        fields.add(create(AlertFields.ALERT_SIGNATURE_ID, 32, STRING));
-        fields.add(create(AlertFields.ALERT_CATEGORY, 33, STRING)); // TODO: Used twice
+        fields.add(create(AlertFields.ALERT_SIGNATURE, 32, STRING));
+        fields.add(create(AlertFields.ALERT_CATEGORY, 33, STRING));
         fields.add(create(VendorFields.VENDOR_ALERT_SEVERITY, 34, STRING));
 
         fields.add(create(PaloAlto9xFields.PAN_ALERT_DIRECTION, 35, STRING));
@@ -358,7 +371,7 @@ public class PaloAlto9xTemplates {
 
         fields.add(create(SourceFields.SOURCE_USER_EMAIL, 50, STRING));
         fields.add(create(EmailFields.EMAIL_SUBJECT, 51, STRING));
-        fields.add(create("target_user_email", 52, STRING)); // TODO: Need constant
+        fields.add(create(UserFields.TARGET_USER_EMAIL, 52, STRING));
         fields.add(create(PaloAlto9xFields.PAN_WILDFIRE_REPORT_ID, 53, LONG));
         fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_1, 54, LONG));
 
@@ -366,7 +379,7 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_3, 56, LONG));
         fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4, 57, LONG));
         fields.add(create(HostFields.HOST_VIRTFW_HOSTNAME, 58, STRING));
-        fields.add(create(HostFields.HOST_HOSTNAME, 59, STRING));
+        fields.add(create(EventFields.EVENT_OBSERVER_HOSTNAME, 59, STRING));
 
         // Field 60 is FUTURE USE
         fields.add(create(SourceFields.SOURCE_VSYS_UUID, 61, STRING));
@@ -378,7 +391,7 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_PARENT_SESSION_ID, 66, STRING));
         fields.add(create(PaloAlto9xFields.PAN_PARENT_START_TIME, 67, STRING));
         fields.add(create(NetworkFields.NETWORK_TUNNEL_TYPE, 68, STRING));
-        // fields.add(create(AlertFields.ALERT_CATEGORY, 69, STRING)); // TODO: Used twice
+        fields.add(create(AlertFields.ALERT_CATEGORY, 69, STRING));
 
         fields.add(create(AlertFields.ALERT_DEFINITIONS_VERSION, 70, STRING));
         // Field 71 is FUTURE USE
@@ -386,10 +399,49 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_PPID, 73, LONG));
         fields.add(create(HttpFields.HTTP_HEADERS, 74, STRING));
 
-        fields.add(create(HttpFields.HTTP_URL_CATEGORY, 75, STRING));
-        fields.add(create("policy_uid", 76, STRING));          // TODO: Need constant
+        fields.add(create(HttpFields.HTTP_URI_CATEGORY, 75, STRING));
+        fields.add(create(PolicyFields.POLICY_UID, 76, STRING));
         fields.add(create(PaloAlto9xFields.PAN_HTTP2, 77, STRING));
         fields.add(create(PaloAlto9xFields.PAN_DYNUSERGROUP_NAME, 78, STRING));
+        fields.add(create(HttpFields.HTTP_XFF, 79, STRING));
+
+        fields.add(create(SourceFields.SOURCE_CATEGORY, 80, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SOURCE_PROFILE, 81, STRING));
+        fields.add(create(SourceFields.SOURCE_DEVICE_MODEL, 82, STRING));
+        fields.add(create(SourceFields.SOURCE_DEVICE_VENDOR, 83, STRING));
+        fields.add(create(SourceFields.SOURCE_OS_NAME, 84, STRING));
+
+        fields.add(create(SourceFields.SOURCE_OS_VERSION, 85, STRING));
+        fields.add(create(SourceFields.SOURCE_HOSTNAME, 86, STRING));
+        fields.add(create(SourceFields.SOURCE_MAC, 87, STRING));
+        fields.add(create(DestinationFields.DESTINATION_CATEGORY, 88, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DESTINATION_PROFILE, 89, STRING));
+
+        fields.add(create(DestinationFields.DESTINATION_DEVICE_MODEL, 90, STRING));
+        fields.add(create(DestinationFields.DESTINATION_DEVICE_VENDOR, 91, STRING));
+        fields.add(create(DestinationFields.DESTINATION_OS_NAME, 92, STRING));
+        fields.add(create(DestinationFields.DESTINATION_OS_VERSION, 93, STRING));
+        fields.add(create(DestinationFields.DESTINATION_HOSTNAME, 94, STRING));
+
+        fields.add(create(DestinationFields.DESTINATION_MAC, 95, STRING));
+        fields.add(create(ContainerFields.CONTAINER_ID, 96, STRING));
+        fields.add(create(ContainerFields.CONTAINER_NAMESPACE, 97, STRING));
+        fields.add(create(ContainerFields.CONTAINER_NAME, 98, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SRC_EDL, 99, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_DST_EDL, 100, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_HOST_ID, 101, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_HOST_SN, 102, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DOMAIN_EDL, 103, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SRC_DAG, 104, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_DST_DAG, 105, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_PARTIAL_HASH, 106, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_HIGH_RES_TIME, 107, STRING));
+        fields.add(create(VendorFields.VENDOR_EVENT_OUTCOME_REASON, 108, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_EVENT_JUSTIFICATION, 109, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_NSDSAI_SST, 110, STRING));
 
         return toTemplate(fields);
     }
@@ -399,7 +451,7 @@ public class PaloAlto9xTemplates {
 
         // Field 0 is FUTURE USE
         fields.add(create(EventFields.EVENT_RECEIVED_TIME, 1, STRING));
-        fields.add(create(HostFields.HOST_ID, 2, STRING));
+        fields.add(create(EventFields.EVENT_OBSERVER_ID, 2, STRING));
         fields.add(create(EventFields.EVENT_LOG_NAME, 3, STRING));
         fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
 
@@ -410,10 +462,10 @@ public class PaloAlto9xTemplates {
         fields.add(create(SourceFields.SOURCE_NAT_IP, 9, STRING));
 
         fields.add(create(DestinationFields.DESTINATION_NAT_IP, 10, STRING));
-        fields.add(create("rule_name", 11, STRING)); // TODO: Need constant
-        fields.add(create(SourceFields.SOURCE_USER, 12, STRING));
-        fields.add(create("target_user", 13, STRING)); // TODO: Need constant
-        fields.add(create(NetworkFields.NETWORK_APPLICATION, 14, STRING));
+        fields.add(create(RuleFields.RULE_NAME, 11, STRING));
+        fields.add(create(SourceFields.SOURCE_USER_NAME, 12, STRING));
+        fields.add(create(DestinationFields.DESTINATION_USER_NAME, 13, STRING));
+        fields.add(create(ApplicationFields.APPLICATION_NAME, 14, STRING));
 
         fields.add(create(HostFields.HOST_VIRTFW_ID, 15, STRING));
         fields.add(create(SourceFields.SOURCE_ZONE, 16, STRING));
@@ -431,17 +483,17 @@ public class PaloAlto9xTemplates {
         fields.add(create(SourceFields.SOURCE_NAT_PORT, 26, LONG));
         fields.add(create(DestinationFields.DESTINATION_NAT_PORT, 27, LONG));
         fields.add(create(PaloAlto9xFields.PAN_FLAGS, 28, STRING));
-        fields.add(create(NetworkFields.NETWORK_PROTOCOL, 29, STRING));
+        fields.add(create(NetworkFields.NETWORK_TRANSPORT, 29, STRING));
 
         fields.add(create(VendorFields.VENDOR_EVENT_ACTION, 30, STRING));
         fields.add(create(NetworkFields.NETWORK_BYTES, 31, LONG));
-        fields.add(create(NetworkFields.NETWORK_BYTES_TX, 32, LONG));
-        fields.add(create(NetworkFields.NETWORK_BYTES_RX, 33, LONG));
+        fields.add(create(SourceFields.SOURCE_BYTES_SENT, 32, LONG));
+        fields.add(create(DestinationFields.DESTINATION_BYTES_SENT, 33, LONG));
         fields.add(create(NetworkFields.NETWORK_PACKETS, 34, LONG));
 
         fields.add(create(EventFields.EVENT_START, 35, STRING));
         fields.add(create(EventFields.EVENT_DURATION, 36, LONG));
-        fields.add(create(HttpFields.HTTP_URL_CATEGORY, 37, STRING));
+        fields.add(create(HttpFields.HTTP_URI_CATEGORY, 37, STRING));
         // Field 38 is FUTURE USE
         fields.add(create(EventFields.EVENT_UID, 39, STRING));
 
@@ -449,9 +501,9 @@ public class PaloAlto9xTemplates {
         fields.add(create(SourceFields.SOURCE_LOCATION_NAME, 41, STRING));
         fields.add(create(DestinationFields.DESTINATION_LOCATION_NAME, 42, STRING));
         // Field 43 is FUTURE USE
-        fields.add(create(SourceFields.SOURCE_PACKETS, 44, LONG));
+        fields.add(create(SourceFields.SOURCE_PACKETS_SENT, 44, LONG));
 
-        fields.add(create(DestinationFields.DESTINATION_PACKETS, 45, LONG));
+        fields.add(create(DestinationFields.DESTINATION_PACKETS_SENT, 45, LONG));
         fields.add(create(PaloAlto9xFields.PAN_SESSION_END_REASON, 46, STRING));
         fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_1, 47, LONG));
         fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_2, 48, LONG));
@@ -459,7 +511,7 @@ public class PaloAlto9xTemplates {
 
         fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4, 50, LONG));
         fields.add(create(HostFields.HOST_VIRTFW_HOSTNAME, 51, STRING));
-        fields.add(create(HostFields.HOST_HOSTNAME, 52, STRING));
+        fields.add(create(EventFields.EVENT_OBSERVER_HOSTNAME, 52, STRING));
         fields.add(create(VendorFields.VENDOR_EVENT_DESCRIPTION, 53, STRING));
         fields.add(create(SourceFields.SOURCE_VSYS_UUID, 54, STRING));
 
@@ -475,7 +527,7 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_SCTP_CHUNKS_TX, 63, STRING));
         fields.add(create(PaloAlto9xFields.PAN_SCTP_CHUNKS_RX, 64, STRING));
 
-        fields.add(create("policy_uid", 65, STRING)); // TODO: Need constant
+        fields.add(create(PolicyFields.POLICY_UID, 65, STRING));
         fields.add(create(PaloAlto9xFields.PAN_HTTP2, 66, STRING));
         fields.add(create(PaloAlto9xFields.PAN_LINK_CHANGES, 67, LONG));
         fields.add(create(PaloAlto9xFields.PAN_SDWAN_POLICY_ID, 68, STRING));
@@ -486,6 +538,42 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_SDWAN_CLUSTER_TYPE, 72, STRING));
         fields.add(create(PaloAlto9xFields.PAN_SDWAN_SITE_NAME, 73, STRING));
         fields.add(create(PaloAlto9xFields.PAN_DYNUSERGROUP_NAME, 74, STRING));
+
+        fields.add(create(HttpFields.HTTP_XFF, 75, STRING));
+        fields.add(create(SourceFields.SOURCE_CATEGORY, 76, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SOURCE_PROFILE, 77, STRING));
+        fields.add(create(SourceFields.SOURCE_DEVICE_MODEL, 78, STRING));
+        fields.add(create(SourceFields.SOURCE_DEVICE_VENDOR, 79, STRING));
+
+        fields.add(create(SourceFields.SOURCE_OS_NAME, 80, STRING));
+        fields.add(create(SourceFields.SOURCE_OS_VERSION, 81, STRING));
+        fields.add(create(SourceFields.SOURCE_HOSTNAME, 82, STRING));
+        fields.add(create(SourceFields.SOURCE_MAC, 83, STRING));
+        fields.add(create(DestinationFields.DESTINATION_CATEGORY, 84, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_DESTINATION_PROFILE, 85, STRING));
+        fields.add(create(DestinationFields.DESTINATION_DEVICE_MODEL, 86, STRING));
+        fields.add(create(DestinationFields.DESTINATION_DEVICE_VENDOR, 87, STRING));
+        fields.add(create(DestinationFields.DESTINATION_OS_NAME, 88, STRING));
+        fields.add(create(DestinationFields.DESTINATION_OS_VERSION, 89, STRING));
+
+        fields.add(create(DestinationFields.DESTINATION_HOSTNAME, 90, STRING));
+        fields.add(create(DestinationFields.DESTINATION_MAC, 91, STRING));
+        fields.add(create(ContainerFields.CONTAINER_ID, 92, STRING));
+        fields.add(create(ContainerFields.CONTAINER_NAMESPACE, 93, STRING));
+        fields.add(create(ContainerFields.CONTAINER_NAME, 94, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_SRC_EDL, 95, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DST_EDL, 96, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_HOST_ID, 97, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_HOST_SN, 98, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SRC_DAG, 99, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_DST_DAG, 100, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SESSION_OWNER, 101, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_HIGH_RES_TIME, 102, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_NSDSAI_SST, 103, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_NSDSAI_SD, 104, STRING));
 
         return toTemplate(fields);
     }

--- a/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplatesTest.java
+++ b/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplatesTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import org.graylog.integrations.inputs.paloalto.PaloAltoParser;
 import org.graylog.schema.AlertFields;
 import org.graylog.schema.ApplicationFields;
+import org.graylog.schema.ContainerFields;
 import org.graylog.schema.DestinationFields;
 import org.graylog.schema.EmailFields;
 import org.graylog.schema.EventFields;
@@ -27,6 +28,8 @@ import org.graylog.schema.FileFields;
 import org.graylog.schema.HostFields;
 import org.graylog.schema.HttpFields;
 import org.graylog.schema.NetworkFields;
+import org.graylog.schema.PolicyFields;
+import org.graylog.schema.RuleFields;
 import org.graylog.schema.SessionFields;
 import org.graylog.schema.SourceFields;
 import org.graylog.schema.ThreatFields;
@@ -38,6 +41,9 @@ import org.graylog2.plugin.journal.RawMessage;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -113,7 +119,7 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(PaloAlto9xFields.PAN_LOG_SUBTYPE), nullValue());
         assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2020/05/31 17:19:44"));
         assertThat(out.getField(SourceFields.SOURCE_IP), is("10.154.8.125"));
-        assertThat(out.getField(SourceFields.SOURCE_USER), is("pancademo\\david.mccoy"));
+        assertThat(out.getField(UserFields.USER_NAME), is("pancademo\\david.mccoy"));
         assertThat(out.getField(HostFields.HOST_VIRTFW_ID), nullValue());
         assertThat(out.getField(ThreatFields.THREAT_CATEGORY), is("compromised-host"));
         assertThat(out.getField(EventFields.EVENT_SEVERITY), is("medium"));
@@ -161,7 +167,6 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(VendorFields.VENDOR_PRIVATE_IP), is("0.0.0.0"));
         assertThat(out.getField(VendorFields.VENDOR_PRIVATE_IPV6), is("0.0.0.0"));
         assertThat(out.getField(PaloAlto9xFields.PAN_GP_HOSTID), is("2c2ec970-de09-444c-b84f-2c0be75e13cd"));
-        // assertThat(out.getField(HostFields.HOST_ID), nullValue());
         assertThat(out.getField(PaloAlto9xFields.PAN_GP_CLIENT_VERSION), is("Browser"));
         assertThat(out.getField(HostFields.HOST_TYPE), is("Windows"));
         assertThat(out.getField(HostFields.HOST_TYPE_VERSION), is("Microsoft Windows 7  Service Pack 1, 64-bit"));
@@ -178,8 +183,61 @@ public class PaloAlto9xTemplatesTest {
     }
 
     @Test
+    public void verifyGlobalProtect913MessageParsing() {
+        String log = "1,2020/04/01 10:49:35,015351000040055,GLOBALPROTECT,0,2305,2020/04/01 10:49:35,vsys1,portal-prelogin,before-login,,,,192.168.0.0-192.168.255.255,,192.168.45.33,0.0.0.0,0.0.0.0,0.0.0.0,2c2ec970-de09-444c-b84f-2c0be75e13cd,,Browser,Windows,\"Microsoft Windows 7  Service Pack 1, 64-bit\",1,,,\"\",success,,0,,0,gp-portal,11,0x0";
+        String rawMessage = SYSLOG_PREFIX + log;
+        RawMessage in = new RawMessage(rawMessage.getBytes());
+
+        Message out = cut.decode(in);
+
+        assertThat(out, notNullValue());
+        assertThat(out.getField(Message.FIELD_FULL_MESSAGE), is(rawMessage));
+        assertThat(out.getField(Message.FIELD_MESSAGE), is(log));
+        assertThat(out.getField(EventFields.EVENT_SOURCE_PRODUCT), is("PAN"));
+
+        assertThat(out.getField(EventFields.EVENT_RECEIVED_TIME), is("2020/04/01 10:49:35"));
+        assertThat(out.getField(HostFields.HOST_ID), is("015351000040055"));
+        assertThat(out.getField(EventFields.EVENT_LOG_NAME), is("GLOBALPROTECT"));
+        assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2020/04/01 10:49:35"));
+        assertThat(out.getField(HostFields.HOST_VIRTFW_ID), is("vsys1"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_EVENT_NAME), is("portal-prelogin"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_TUNNEL_STAGE), is("before-login"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_AUTH_METHOD), nullValue());
+        assertThat(out.getField(NetworkFields.NETWORK_TUNNEL_TYPE), nullValue());
+        assertThat(out.getField(UserFields.USER_NAME), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_SOURCE_REGION), is("192.168.0.0-192.168.255.255"));
+        assertThat(out.getField(SourceFields.SOURCE_HOSTNAME), nullValue());
+        assertThat(out.getField(VendorFields.VENDOR_PUBLIC_IP), is("192.168.45.33"));
+        assertThat(out.getField(VendorFields.VENDOR_PUBLIC_IPV6), is("0.0.0.0"));
+        assertThat(out.getField(VendorFields.VENDOR_PRIVATE_IP), is("0.0.0.0"));
+        assertThat(out.getField(VendorFields.VENDOR_PRIVATE_IPV6), is("0.0.0.0"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_GP_HOSTID), is("2c2ec970-de09-444c-b84f-2c0be75e13cd"));
+        assertThat(out.getField(SourceFields.SOURCE_ID), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_GP_CLIENT_VERSION), is("Browser"));
+        assertThat(out.getField(SourceFields.SOURCE_OS_NAME), is("Windows"));
+        assertThat(out.getField(SourceFields.SOURCE_OS_VERSION), is("Microsoft Windows 7  Service Pack 1, 64-bit"));
+        assertThat(out.getField(EventFields.EVENT_REPEAT_COUNT), is(1L));
+        assertThat(out.getField(PaloAlto9xFields.PAN_GP_REASON), nullValue());
+        assertThat(out.getField(EventFields.EVENT_ERROR_DESCRIPTION), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_GP_ERROR_EXTENDED), nullValue());
+        assertThat(out.getField(VendorFields.VENDOR_EVENT_OUTCOME), is("success"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_GP_LOCATION_NAME), nullValue());
+        assertThat(out.getField(NetworkFields.NETWORK_TUNNEL_DURATION), is(0L));
+        assertThat(out.getField(PaloAlto9xFields.PAN_GP_CONNECT_METHOD), nullValue());
+        assertThat(out.getField(EventFields.EVENT_ERROR_CODE), is(0L));
+        assertThat(out.getField(DestinationFields.DESTINATION_HOSTNAME), is("gp-portal"));
+        assertThat(out.getField(EventFields.EVENT_UID), is("11"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_LOG_PANORAMA), is("0x0"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_SELECTION_TYPE), nullValue());
+        assertThat(out.getField(ApplicationFields.APPLICATION_RESPONSE_TIME), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_GATEWAY_PRIORITY), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_ATTEMPTED_GATEWAYS), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_GATEWAY), nullValue());
+    }
+
+    @Test
     public void verifyHipMatchMessageParsing() {
-        String log = "0,2020/03/18 04:03:19,,HIPMATCH,0,0,2020/03/18 04:02:55,user1@prismaissase.com,vsys1,DFWMACW12KG8WL,Mac,172.1.19.3,test-Object,1,object,0,0,28,0x8600000000000000,15,18,0,0,,GP cloud service,1,0.0.0.0,4c:32:75:9a:5f:ed,";
+        String log = "0,2020/03/18 04:03:19,,HIPMATCH,0,0,2020/03/18 04:02:55,user1@prismaissase.com,vsys1,DFWMACW12KG8WL,Mac,172.1.19.3,test-Object,1,object,0,0,28,0x8600000000000000,15,18,0,0,,GP cloud service,1,0.0.0.0,4c:32:75:9a:5f:ed,hostId,MAC Address,YYYY-MM-DDThh:ss:sssTZD";
         String rawMessage = SYSLOG_PREFIX + log;
         RawMessage in = new RawMessage(rawMessage.getBytes());
 
@@ -195,11 +253,11 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(EventFields.EVENT_LOG_NAME), is("HIPMATCH"));
         assertThat(out.getField(PaloAlto9xFields.PAN_LOG_SUBTYPE), is("0"));
         assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2020/03/18 04:02:55"));
-        assertThat(out.getField(SourceFields.SOURCE_USER), is("user1@prismaissase.com"));
+        assertThat(out.getField(UserFields.USER_NAME), is("user1@prismaissase.com"));
         assertThat(out.getField(HostFields.HOST_VIRTFW_ID), is("vsys1"));
-        assertThat(out.getField(EventFields.EVENT_OBSERVER_HOSTNAME), is("DFWMACW12KG8WL"));
+        assertThat(out.getField(HostFields.HOST_HOSTNAME), is("DFWMACW12KG8WL"));
         assertThat(out.getField(HostFields.HOST_TYPE), is("Mac"));
-        assertThat(out.getField(SourceFields.SOURCE_IP), is("172.1.19.3"));
+        assertThat(out.getField(HostFields.HOST_IP), is("172.1.19.3"));
         assertThat(out.getField(PaloAlto9xFields.PAN_HIP), is("test-Object"));
         assertThat(out.getField(EventFields.EVENT_REPEAT_COUNT), is(1L));
         assertThat(out.getField(PaloAlto9xFields.PAN_HIP_TYPE), is("object"));
@@ -210,16 +268,18 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_3), is(0L));
         assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4), is(0L));
         assertThat(out.getField(HostFields.HOST_VIRTFW_HOSTNAME), nullValue());
-        assertThat(out.getField(HostFields.HOST_HOSTNAME), is("GP cloud service"));
+        assertThat(out.getField(EventFields.EVENT_OBSERVER_HOSTNAME), is("GP cloud service"));
         assertThat(out.getField(HostFields.HOST_VIRTFW_UID), is("1"));
-        assertThat(out.getField(SourceFields.SOURCE_IPV6), is("0.0.0.0"));
+        assertThat(out.getField(HostFields.HOST_IPV6), is("0.0.0.0"));
         assertThat(out.getField(PaloAlto9xFields.PAN_GP_HOSTID), is("4c:32:75:9a:5f:ed"));
-        assertThat(out.getField(HostFields.HOST_ID), nullValue());
+        assertThat(out.getField(HostFields.HOST_ID), is("hostId"));
+        assertThat(out.getField(SourceFields.SOURCE_MAC), is("MAC Address"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_HIGH_RES_TIME), is("YYYY-MM-DDThh:ss:sssTZD"));
     }
 
     @Test
     public void verifySystemMessageParsing() {
-        String log = "1,2020/03/19 10:12:57,007000016479,SYSTEM,general,0,2020/03/19 10:12:57,,general,,0,0,general,informational,\"Failed to connect to address: (null) port: 3978, conn id: triallr-(null)-2-192.168.1.232\",21682381,0x8000000000000000,0,0,0,0,,sg2";
+        String log = "1,2020/03/19 10:12:57,007000016479,SYSTEM,general,0,2020/03/19 10:12:57,,general,,0,0,general,informational,\"Failed to connect to address: (null) port: 3978, conn id: triallr-(null)-2-192.168.1.232\",21682381,0x8000000000000000,0,0,0,0,,sg2,YYYY-MM-DDThh:ss:sssTZD";
         String rawMessage = SYSLOG_PREFIX + log;
         RawMessage in = new RawMessage(rawMessage.getBytes());
 
@@ -249,6 +309,7 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4), is(0L));
         assertThat(out.getField(HostFields.HOST_VIRTFW_HOSTNAME), nullValue());
         assertThat(out.getField(HostFields.HOST_HOSTNAME), is("sg2"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_HIGH_RES_TIME), is("YYYY-MM-DDThh:ss:sssTZD"));
     }
 
     @Test
@@ -266,7 +327,7 @@ public class PaloAlto9xTemplatesTest {
 
         // Field 0 is FUTURE USE
         assertThat(out.getField(EventFields.EVENT_RECEIVED_TIME), is("2020/05/19 07:37:27"));
-        assertThat(out.getField(HostFields.HOST_ID), is("007200002536"));
+        assertThat(out.getField(EventFields.EVENT_OBSERVER_ID), is("007200002536"));
         assertThat(out.getField(EventFields.EVENT_LOG_NAME), is("THREAT"));
         assertThat(out.getField(PaloAlto9xFields.PAN_LOG_SUBTYPE), is("spyware"));
 
@@ -277,9 +338,9 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(SourceFields.SOURCE_NAT_IP), nullValue());
 
         assertThat(out.getField(DestinationFields.DESTINATION_NAT_IP), nullValue());
-        assertThat(out.getField("rule_name"), is("General Business Apps")); // TODO: Need constant
-        assertThat(out.getField(SourceFields.SOURCE_USER), is("pancademo\\andy.miller"));
-        assertThat(out.getField("target_user"), nullValue()); // TODO: Need constant
+        assertThat(out.getField(RuleFields.RULE_NAME), is("General Business Apps"));
+        assertThat(out.getField(SourceFields.SOURCE_USER_NAME), is("pancademo\\andy.miller"));
+        assertThat(out.getField(DestinationFields.DESTINATION_USER_NAME), nullValue());
         assertThat(out.getField(ApplicationFields.APPLICATION_NAME), is("unknown-udp"));
 
         assertThat(out.getField(HostFields.HOST_VIRTFW_ID), is("vsys1"));
@@ -298,12 +359,17 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(SourceFields.SOURCE_NAT_PORT), is(0L));
         assertThat(out.getField(DestinationFields.DESTINATION_NAT_PORT), is(0L));
         assertThat(out.getField(PaloAlto9xFields.PAN_FLAGS), is("0x80002000"));
-        assertThat(out.getField(NetworkFields.NETWORK_PROTOCOL), is("udp"));
+        assertThat(out.getField(NetworkFields.NETWORK_TRANSPORT), is("udp"));
 
         assertThat(out.getField(VendorFields.VENDOR_EVENT_ACTION), is("drop"));
-        assertThat(out.getField(AlertFields.ALERT_INDICATOR), nullValue()); // TODO: Key used twice
-        assertThat(out.getField(AlertFields.ALERT_SIGNATURE_ID), is("ZeroAccess.Gen Command and Control Traffic(13235)"));
-        assertThat(out.getField(AlertFields.ALERT_CATEGORY), is("any"));
+        assertThat(out.getField(AlertFields.ALERT_INDICATOR), nullValue());
+        assertThat(out.getField(AlertFields.ALERT_SIGNATURE), is("ZeroAccess.Gen Command and Control Traffic(13235)"));
+
+        assertThat(out.getField(AlertFields.ALERT_CATEGORY), notNullValue());
+        List<String> alertCategoryList = (List) out.getField(AlertFields.ALERT_CATEGORY);
+        assertThat(alertCategoryList.size(), is(2));
+        assertThat(alertCategoryList, hasItems("any", "botnet"));
+
         assertThat(out.getField(VendorFields.VENDOR_ALERT_SEVERITY), is("critical"));
 
         assertThat(out.getField(PaloAlto9xFields.PAN_ALERT_DIRECTION), is("client-to-server"));
@@ -326,7 +392,7 @@ public class PaloAlto9xTemplatesTest {
 
         assertThat(out.getField(SourceFields.SOURCE_USER_EMAIL), nullValue());
         assertThat(out.getField(EmailFields.EMAIL_SUBJECT), nullValue());
-        assertThat(out.getField("target_user_email"), nullValue()); // TODO: Need constant
+        assertThat(out.getField(UserFields.TARGET_USER_EMAIL), nullValue());
         assertThat(out.getField(PaloAlto9xFields.PAN_WILDFIRE_REPORT_ID), is(0L));
         assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_1), is(31L));
 
@@ -334,7 +400,7 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_3), is(0L));
         assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4), is(0L));
         assertThat(out.getField(HostFields.HOST_VIRTFW_HOSTNAME), nullValue());
-        assertThat(out.getField(HostFields.HOST_HOSTNAME), is("us1"));
+        assertThat(out.getField(EventFields.EVENT_OBSERVER_HOSTNAME), is("us1"));
 
         // Field 60 is FUTURE USE
         assertThat(out.getField(SourceFields.SOURCE_VSYS_UUID), nullValue());
@@ -346,7 +412,6 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(PaloAlto9xFields.PAN_PARENT_SESSION_ID), is("0"));
         assertThat(out.getField(PaloAlto9xFields.PAN_PARENT_START_TIME), nullValue());
         assertThat(out.getField(NetworkFields.NETWORK_TUNNEL_TYPE), is("N/A"));
-        // assertThat(out.getField(AlertFields.ALERT_CATEGORY), is("botnet")); // TODO: Used twice
 
         assertThat(out.getField(AlertFields.ALERT_DEFINITIONS_VERSION), is("AppThreat-8270-6076"));
         // Field 71 is FUTURE USE
@@ -354,10 +419,84 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(PaloAlto9xFields.PAN_PPID), is(4294967295L));
         assertThat(out.getField(HttpFields.HTTP_HEADERS), nullValue());
 
-        assertThat(out.getField(HttpFields.HTTP_URL_CATEGORY), nullValue());
-        assertThat(out.getField("policy_uid"), is("f0724261-cf8b-479b-8208-fd3c7ac3af0b")); // TODO: Need constant
+        assertThat(out.getField(HttpFields.HTTP_URI_CATEGORY), nullValue());
+        assertThat(out.getField(PolicyFields.POLICY_UID), is("f0724261-cf8b-479b-8208-fd3c7ac3af0b"));
         assertThat(out.getField(PaloAlto9xFields.PAN_HTTP2), is("0"));
         assertThat(out.getField(PaloAlto9xFields.PAN_DYNUSERGROUP_NAME), nullValue());
+        assertThat(out.getField(HttpFields.HTTP_XFF), nullValue());
+
+        assertThat(out.getField(SourceFields.SOURCE_CATEGORY), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_SOURCE_PROFILE), nullValue());
+        assertThat(out.getField(SourceFields.SOURCE_DEVICE_MODEL), nullValue());
+        assertThat(out.getField(SourceFields.SOURCE_DEVICE_VENDOR), nullValue());
+        assertThat(out.getField(SourceFields.SOURCE_OS_NAME), nullValue());
+
+        assertThat(out.getField(SourceFields.SOURCE_OS_VERSION), nullValue());
+        assertThat(out.getField(SourceFields.SOURCE_HOSTNAME), nullValue());
+        assertThat(out.getField(SourceFields.SOURCE_MAC), nullValue());
+        assertThat(out.getField(DestinationFields.DESTINATION_CATEGORY), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_DESTINATION_PROFILE), nullValue());
+
+        assertThat(out.getField(DestinationFields.DESTINATION_DEVICE_MODEL), nullValue());
+        assertThat(out.getField(DestinationFields.DESTINATION_DEVICE_VENDOR), nullValue());
+        assertThat(out.getField(DestinationFields.DESTINATION_OS_NAME), nullValue());
+        assertThat(out.getField(DestinationFields.DESTINATION_OS_VERSION), nullValue());
+        assertThat(out.getField(DestinationFields.DESTINATION_HOSTNAME), nullValue());
+
+        assertThat(out.getField(DestinationFields.DESTINATION_MAC), nullValue());
+        assertThat(out.getField(ContainerFields.CONTAINER_ID), nullValue());
+        assertThat(out.getField(ContainerFields.CONTAINER_NAMESPACE), nullValue());
+        assertThat(out.getField(ContainerFields.CONTAINER_NAME), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_SRC_EDL), nullValue());
+
+        assertThat(out.getField(PaloAlto9xFields.PAN_DST_EDL), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_HOST_ID), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_HOST_SN), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_DOMAIN_EDL), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_SRC_DAG), nullValue());
+
+        assertThat(out.getField(PaloAlto9xFields.PAN_DST_DAG), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_PARTIAL_HASH), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_HIGH_RES_TIME), nullValue());
+        assertThat(out.getField(VendorFields.VENDOR_EVENT_OUTCOME_REASON), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_EVENT_JUSTIFICATION), nullValue());
+
+        assertThat(out.getField(PaloAlto9xFields.PAN_NSDSAI_SST), nullValue());
+    }
+
+    @Test
+    public void verifyThreatMessageParsing_withRepeatedSameXFF() {
+        String log = "1,2020/05/19 07:37:27,007200002536,THREAT,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,FOO,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,FOO,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,";
+        String rawMessage = SYSLOG_PREFIX + log;
+        RawMessage in = new RawMessage(rawMessage.getBytes());
+
+        Message out = cut.decode(in);
+
+        assertThat(out, notNullValue());
+        assertThat(out.getField(Message.FIELD_FULL_MESSAGE), is(rawMessage));
+        assertThat(out.getField(Message.FIELD_MESSAGE), is(log));
+        assertThat(out.getField(EventFields.EVENT_SOURCE_PRODUCT), is("PAN"));
+
+        assertThat(out.getField(HttpFields.HTTP_XFF), is("FOO"));
+    }
+
+    @Test
+    public void verifyThreatMessageParsing_withDifferentXFF() {
+        String log = "1,2020/05/19 07:37:27,007200002536,THREAT,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,FOO,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,BAR,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,";
+        String rawMessage = SYSLOG_PREFIX + log;
+        RawMessage in = new RawMessage(rawMessage.getBytes());
+
+        Message out = cut.decode(in);
+
+        assertThat(out, notNullValue());
+        assertThat(out.getField(Message.FIELD_FULL_MESSAGE), is(rawMessage));
+        assertThat(out.getField(Message.FIELD_MESSAGE), is(log));
+        assertThat(out.getField(EventFields.EVENT_SOURCE_PRODUCT), is("PAN"));
+
+        assertThat(out.getField(HttpFields.HTTP_XFF), notNullValue());
+        List<String> xffList = (List) out.getField(HttpFields.HTTP_XFF);
+        assertThat(xffList.size(), is(2));
+        assertThat(xffList, hasItems("FOO", "BAR"));
     }
 
     @Test
@@ -375,7 +514,7 @@ public class PaloAlto9xTemplatesTest {
 
         // Field 0 is FUTURE USE
         assertThat(out.getField(EventFields.EVENT_RECEIVED_TIME), is("2020/05/19 07:34:54"));
-        assertThat(out.getField(HostFields.HOST_ID), is("007200002536"));
+        assertThat(out.getField(EventFields.EVENT_OBSERVER_ID), is("007200002536"));
         assertThat(out.getField(EventFields.EVENT_LOG_NAME), is("TRAFFIC"));
         assertThat(out.getField(PaloAlto9xFields.PAN_LOG_SUBTYPE), is("end"));
 
@@ -386,10 +525,10 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(SourceFields.SOURCE_NAT_IP), nullValue());
 
         assertThat(out.getField(DestinationFields.DESTINATION_NAT_IP), nullValue());
-        assertThat(out.getField("rule_name"), is("IT Sanctioned SaaS Apps-443")); // TODO: Need constant
-        assertThat(out.getField(SourceFields.SOURCE_USER), is("pancademo\\steven.reid"));
-        assertThat(out.getField("target_user_name"), nullValue()); // TODO: Need constant
-        assertThat(out.getField(NetworkFields.NETWORK_APPLICATION), is("ssl"));
+        assertThat(out.getField(RuleFields.RULE_NAME), is("IT Sanctioned SaaS Apps-443")); // TODO: Need constant
+        assertThat(out.getField(SourceFields.SOURCE_USER_NAME), is("pancademo\\steven.reid"));
+        assertThat(out.getField(DestinationFields.DESTINATION_USER_NAME), nullValue());
+        assertThat(out.getField(ApplicationFields.APPLICATION_NAME), is("ssl"));
 
         assertThat(out.getField(HostFields.HOST_VIRTFW_ID), is("vsys1"));
         assertThat(out.getField(SourceFields.SOURCE_ZONE), is("L3-TAP"));
@@ -407,17 +546,17 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(SourceFields.SOURCE_NAT_PORT), is(0L));
         assertThat(out.getField(DestinationFields.DESTINATION_NAT_PORT), is(0L));
         assertThat(out.getField(PaloAlto9xFields.PAN_FLAGS), is("0x6c"));
-        assertThat(out.getField(NetworkFields.NETWORK_PROTOCOL), is("tcp"));
+        assertThat(out.getField(NetworkFields.NETWORK_TRANSPORT), is("tcp"));
 
         assertThat(out.getField(VendorFields.VENDOR_EVENT_ACTION), is("allow"));
         assertThat(out.getField(NetworkFields.NETWORK_BYTES), is(6802L));
-        assertThat(out.getField(NetworkFields.NETWORK_BYTES_TX), is(3876L));
-        assertThat(out.getField(NetworkFields.NETWORK_BYTES_RX), is(2926L));
+        assertThat(out.getField(SourceFields.SOURCE_BYTES_SENT), is(3876L));
+        assertThat(out.getField(DestinationFields.DESTINATION_BYTES_SENT), is(2926L));
         assertThat(out.getField(NetworkFields.NETWORK_PACKETS), is(26L));
 
         assertThat(out.getField(EventFields.EVENT_START), is("2020/05/19 07:32:48"));
         assertThat(out.getField(EventFields.EVENT_DURATION), is(97L));
-        assertThat(out.getField(HttpFields.HTTP_URL_CATEGORY), is("financial-services"));
+        assertThat(out.getField(HttpFields.HTTP_URI_CATEGORY), is("financial-services"));
         // Field 38 is FUTURE USE
         assertThat(out.getField(EventFields.EVENT_UID), is("18621234943"));
 
@@ -425,9 +564,9 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(SourceFields.SOURCE_LOCATION_NAME), is("10.0.0.0-10.255.255.255"));
         assertThat(out.getField(DestinationFields.DESTINATION_LOCATION_NAME), is("United States"));
         // Field 43 is FUTURE USE
-        assertThat(out.getField(SourceFields.SOURCE_PACKETS), is(17L));
+        assertThat(out.getField(SourceFields.SOURCE_PACKETS_SENT), is(17L));
 
-        assertThat(out.getField(DestinationFields.DESTINATION_PACKETS), is(9L));
+        assertThat(out.getField(DestinationFields.DESTINATION_PACKETS_SENT), is(9L));
         assertThat(out.getField(PaloAlto9xFields.PAN_SESSION_END_REASON), is("tcp-rst-from-server"));
         assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_1), is(31L));
         assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_2), is(12L));
@@ -435,7 +574,7 @@ public class PaloAlto9xTemplatesTest {
 
         assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4), is(0L));
         assertThat(out.getField(HostFields.HOST_VIRTFW_HOSTNAME), nullValue());
-        assertThat(out.getField(HostFields.HOST_HOSTNAME), is("us1"));
+        assertThat(out.getField(EventFields.EVENT_OBSERVER_HOSTNAME), is("us1"));
         assertThat(out.getField(VendorFields.VENDOR_EVENT_DESCRIPTION), is("from-policy"));
         assertThat(out.getField(SourceFields.SOURCE_VSYS_UUID), nullValue());
 
@@ -451,7 +590,7 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(PaloAlto9xFields.PAN_SCTP_CHUNKS_TX), is("0"));
         assertThat(out.getField(PaloAlto9xFields.PAN_SCTP_CHUNKS_RX), is("0"));
 
-        assertThat(out.getField("policy_uid"), is("30468339-a760-46b2-b80b-ee873e6d11e4")); // TODO: Need constant
+        assertThat(out.getField(PolicyFields.POLICY_UID), is("30468339-a760-46b2-b80b-ee873e6d11e4"));
         assertThat(out.getField(PaloAlto9xFields.PAN_HTTP2), is("0"));
         assertThat(out.getField(PaloAlto9xFields.PAN_LINK_CHANGES), is(0L));
         assertThat(out.getField(PaloAlto9xFields.PAN_SDWAN_POLICY_ID), nullValue());
@@ -462,5 +601,41 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(PaloAlto9xFields.PAN_SDWAN_CLUSTER_TYPE), nullValue());
         assertThat(out.getField(PaloAlto9xFields.PAN_SDWAN_SITE_NAME), nullValue());
         assertThat(out.getField(PaloAlto9xFields.PAN_DYNUSERGROUP_NAME), nullValue());
+
+         assertThat(out.getField(HttpFields.HTTP_XFF), nullValue());
+         assertThat(out.getField(SourceFields.SOURCE_CATEGORY), nullValue());
+         assertThat(out.getField(PaloAlto9xFields.PAN_SOURCE_PROFILE), nullValue());
+         assertThat(out.getField(SourceFields.SOURCE_DEVICE_MODEL), nullValue());
+         assertThat(out.getField(SourceFields.SOURCE_DEVICE_VENDOR), nullValue());
+
+         assertThat(out.getField(SourceFields.SOURCE_OS_NAME), nullValue());
+         assertThat(out.getField(SourceFields.SOURCE_OS_VERSION), nullValue());
+         assertThat(out.getField(SourceFields.SOURCE_HOSTNAME), nullValue());
+         assertThat(out.getField(SourceFields.SOURCE_MAC), nullValue());
+         assertThat(out.getField(DestinationFields.DESTINATION_CATEGORY), nullValue());
+
+         assertThat(out.getField(PaloAlto9xFields.PAN_DESTINATION_PROFILE), nullValue());
+         assertThat(out.getField(DestinationFields.DESTINATION_DEVICE_MODEL), nullValue());
+         assertThat(out.getField(DestinationFields.DESTINATION_DEVICE_VENDOR), nullValue());
+         assertThat(out.getField(DestinationFields.DESTINATION_OS_NAME), nullValue());
+         assertThat(out.getField(DestinationFields.DESTINATION_OS_VERSION), nullValue());
+
+         assertThat(out.getField(DestinationFields.DESTINATION_HOSTNAME), nullValue());
+         assertThat(out.getField(DestinationFields.DESTINATION_MAC), nullValue());
+         assertThat(out.getField(ContainerFields.CONTAINER_ID), nullValue());
+         assertThat(out.getField(ContainerFields.CONTAINER_NAMESPACE), nullValue());
+         assertThat(out.getField(ContainerFields.CONTAINER_NAME), nullValue());
+
+         assertThat(out.getField(PaloAlto9xFields.PAN_SRC_EDL), nullValue());
+         assertThat(out.getField(PaloAlto9xFields.PAN_DST_EDL), nullValue());
+         assertThat(out.getField(PaloAlto9xFields.PAN_HOST_ID), nullValue());
+         assertThat(out.getField(PaloAlto9xFields.PAN_HOST_SN), nullValue());
+         assertThat(out.getField(PaloAlto9xFields.PAN_SRC_DAG), nullValue());
+
+         assertThat(out.getField(PaloAlto9xFields.PAN_DST_DAG), nullValue());
+         assertThat(out.getField(PaloAlto9xFields.PAN_SESSION_OWNER), nullValue());
+         assertThat(out.getField(PaloAlto9xFields.PAN_HIGH_RES_TIME), nullValue());
+         assertThat(out.getField(PaloAlto9xFields.PAN_NSDSAI_SST), nullValue());
+         assertThat(out.getField(PaloAlto9xFields.PAN_NSDSAI_SD), nullValue());
     }
 }


### PR DESCRIPTION
Palo Alto Networks has released the schemas for PAN-OS 10.  This change updates the Palo Alto 9.x input to support the PAN-OS 10 schemas and also makes some other requested field changes.  One additional change in this PR is that when multiple instances of the same key are used to build a Palo Alto message, the message field will be converted to a list of all unique values.

The changes to existing fields and list conversion behavior were tested with JUnit tests.  No test data is available to test the PAN-OS 10 schema changes.