### PR TITLE
Update Slack plugin to allow Discord webhooks

### DIFF
--- a/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfig.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfig.java
@@ -43,7 +43,7 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
 
     public static final String TYPE_NAME = "slack-notification-v1";
 
-    private final String regex = "https:\\/\\/(hooks.slack.com\\/services\\/|discord.com\\/api\\/webhooks.*\\/slack)";
+    private final String regex = "https:\\/\\/(hooks.slack.com\\/services\\/|.*\\.?discord(app)?.com\\/api\\/webhooks.*\\/slack)";
     private final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
     private static final String HEX_COLOR = "#ff0500";
 

--- a/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfig.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfig.java
@@ -43,7 +43,7 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
 
     public static final String TYPE_NAME = "slack-notification-v1";
 
-    private final String regex = "https:\\/\\/hooks.slack.com\\/services\\/";
+    private final String regex = "https:\\/\\/(hooks.slack.com\\/services\\/|discord.com\\/api\\/webhooks.*\\/slack)";
     private final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
     private static final String HEX_COLOR = "#ff0500";
 

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigTest.java
@@ -36,9 +36,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SlackEventNotificationConfigTest {
 
     @Test
-    public void validate_succeeds_whenWebhookUrlIsValid() {
+    public void validate_succeeds_whenWebhookUrlIsValidSlackUrl() {
         SlackEventNotificationConfig slackEventNotificationConfig = SlackEventNotificationConfig.builder()
                 .webhookUrl("https://hooks.slack.com/services/xxxx/xxxx/xxxxxxx")
+                .build();
+        ValidationResult result = slackEventNotificationConfig.validate();
+        Map errors = result.getErrors();
+        assertThat(errors).size().isEqualTo(0);
+    }
+
+    @Test
+    public void validate_succeeds_whenWebhookUrlIsValidDiscordSlackUrl() {
+        SlackEventNotificationConfig slackEventNotificationConfig = SlackEventNotificationConfig.builder()
+                .webhookUrl("https://discord.com/api/webhooks/xxxx/xxXXXxxxxxxxxx/slack")
                 .build();
         ValidationResult result = slackEventNotificationConfig.validate();
         Map errors = result.getErrors();

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigTest.java
@@ -56,6 +56,16 @@ public class SlackEventNotificationConfigTest {
     }
 
     @Test
+    public void validate_succeeds_whenWebhookUrlIsValidDiscordappSlackUrl() {
+        SlackEventNotificationConfig slackEventNotificationConfig = SlackEventNotificationConfig.builder()
+                .webhookUrl("https://discordapp.com/api/webhooks/xxxx/xxXXXxxxxxxxxx/slack")
+                .build();
+        ValidationResult result = slackEventNotificationConfig.validate();
+        Map errors = result.getErrors();
+        assertThat(errors).size().isEqualTo(0);
+    }
+
+    @Test
     public void validate_failsAndReturnsAnError_whenWebhookUrlIsInvalid() {
         SlackEventNotificationConfig slackEventNotificationConfig = SlackEventNotificationConfig.builder()
                 .webhookUrl("A67888900000")


### PR DESCRIPTION
Per [Discord documentation](https://birdie0.github.io/discord-webhooks-guide/other/slack_formatting.html), Discord webhooks support messages in Slack format.  However, due to the current webhook URL validation, customers cannot use the Slack Notification plugin to send messages to Discord.  This change updates the webhook validation pattern to also accept properly formatted Discord webhook URLs.

Added JUnit test case to verify validation passes for Discord webhooks.

Validated on Discord
<img width="742" alt="Screen Shot 2020-11-23 at 9 39 19 AM" src="https://user-images.githubusercontent.com/6466251/99982194-e4500000-2d6f-11eb-9274-377fc9d1c4b5.png">
