### PR TITLE
Merge Slack-Discord update to 4.0.1

### DIFF
--- a/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfig.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfig.java
@@ -43,7 +43,7 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
 
     public static final String TYPE_NAME = "slack-notification-v1";
 
-    private final String regex = "https:\\/\\/hooks.slack.com\\/services\\/";
+    private final String regex = "https:\\/\\/(hooks.slack.com\\/services\\/|.*\\.?discord(app)?.com\\/api\\/webhooks.*\\/slack)";
     private final Pattern pattern = Pattern.compile(regex, Pattern.MULTILINE);
     private static final String HEX_COLOR = "#ff0500";
 

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigTest.java
@@ -36,9 +36,29 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SlackEventNotificationConfigTest {
 
     @Test
-    public void validate_succeeds_whenWebhookUrlIsValid() {
+    public void validate_succeeds_whenWebhookUrlIsValidSlackUrl() {
         SlackEventNotificationConfig slackEventNotificationConfig = SlackEventNotificationConfig.builder()
                 .webhookUrl("https://hooks.slack.com/services/xxxx/xxxx/xxxxxxx")
+                .build();
+        ValidationResult result = slackEventNotificationConfig.validate();
+        Map errors = result.getErrors();
+        assertThat(errors).size().isEqualTo(0);
+    }
+
+    @Test
+    public void validate_succeeds_whenWebhookUrlIsValidDiscordSlackUrl() {
+        SlackEventNotificationConfig slackEventNotificationConfig = SlackEventNotificationConfig.builder()
+                .webhookUrl("https://discord.com/api/webhooks/xxxx/xxXXXxxxxxxxxx/slack")
+                .build();
+        ValidationResult result = slackEventNotificationConfig.validate();
+        Map errors = result.getErrors();
+        assertThat(errors).size().isEqualTo(0);
+    }
+
+    @Test
+    public void validate_succeeds_whenWebhookUrlIsValidDiscordappSlackUrl() {
+        SlackEventNotificationConfig slackEventNotificationConfig = SlackEventNotificationConfig.builder()
+                .webhookUrl("https://discordapp.com/api/webhooks/xxxx/xxXXXxxxxxxxxx/slack")
                 .build();
         ValidationResult result = slackEventNotificationConfig.validate();
         Map errors = result.getErrors();


### PR DESCRIPTION
This is a backport of #661 to the `4.0` branch for the `4.0.1` bugfix release.

Previously, the Slack notification plugin only allowed webhook URLs for Slack.  However, Discord also allows Slack-formatted messages to be sent to its own webhook URLs.  In order to increase the usefulness of the Slack notification plugin, this change updates the webhook validation to allow both Slack and Discord webhook URLs.