### PR TITLE
Initial version of USERID parsing for Palo9x input

### DIFF
--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoMessageType.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoMessageType.java
@@ -25,5 +25,6 @@ public enum PaloAltoMessageType {
     CORRELATION,
     HIP,
     GLOBAL_PROTECT_PRE_9_1_3,
-    GLOBAL_PROTECT_9_1_3
+    GLOBAL_PROTECT_9_1_3,
+    USERID
 }

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodec.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodec.java
@@ -113,7 +113,7 @@ public class PaloAlto9xCodec implements Codec {
                     message.addFields(fieldProducer.parseFields(GLOBAL_PROTECT_PRE_9_1_3, p.fields()));
                     break;
                 } else {
-                    LOG.error("Unsupported PAN type [{}]. Not adding any parsed fields.", p.panType());
+                    LOG.info("Received log for unsupported PAN type [{}]. Will not parse.", p.panType());
                 }
         }
 

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodec.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodec.java
@@ -45,6 +45,7 @@ import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.HIP;
 import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.SYSTEM;
 import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.THREAT;
 import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.TRAFFIC;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.USERID;
 
 public class PaloAlto9xCodec implements Codec {
     private static final Logger LOG = LoggerFactory.getLogger(PaloAlto9xCodec.class);
@@ -102,6 +103,9 @@ public class PaloAlto9xCodec implements Codec {
             case "GLOBALPROTECT":
                 // For PAN v9.1.3 and later, Global Protect has type in the expected position
                 message.addFields(fieldProducer.parseFields(GLOBAL_PROTECT_9_1_3, p.fields()));
+                break;
+            case "USERID":
+                message.addFields(fieldProducer.parseFields(USERID, p.fields()));
                 break;
             default:
                 //For PAN v9.1.2 and earlier, Global Protect has type in position 5 rather than position 3

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xFields.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xFields.java
@@ -25,6 +25,9 @@ public class PaloAlto9xFields {
     public static final String PAN_BEFORE_CHANGE_DETAIL = "pan_before_change_detail";
 
     public static final String PAN_CLOUD_HOSTNAME = "pan_cloud_hostname";
+    public static final String PAN_DATASOURCE = "pan_datasource";
+    public static final String PAN_DATASOURCE_NAME = "pan_datasource_name";
+    public static final String PAN_DATASOURCE_TYPE = "pan_datasource_type";
     public static final String PAN_DESTINATION_PROFILE = "pan_destination_profile";
     public static final String PAN_DEV_GROUP_LEVEL_1 = "pan_dev_group_level_1";
     public static final String PAN_DEV_GROUP_LEVEL_2 = "pan_dev_group_level_2";
@@ -40,6 +43,9 @@ public class PaloAlto9xFields {
     public static final String PAN_EVENT_OBJECT = "pan_event_object";
     public static final String PAN_EVENT_JUSTIFICATION = "pan_event_justification";
     public static final String PAN_EVIDENCE = "pan_evidence";
+    public static final String PAN_FACTOR_COMPLETION_TIME = "pan_factor_completion_time";
+    public static final String PAN_FACTOR_NUMBER = "pan_factor_number";
+    public static final String PAN_FACTOR_TYPE = "pan_factor_type";
     public static final String PAN_FLAGS = "pan_flags";
 
     public static final String PAN_GATEWAY = "pan_gateway";
@@ -94,12 +100,15 @@ public class PaloAlto9xFields {
     public static final String PAN_SESSION_OWNER = "pan_session_owner";
     public static final String PAN_SOURCE_PROFILE = "pan_source_profile";
     public static final String PAN_SOURCE_REGION = "pan_source_region";
+    public static final String PAN_SOURCE_USER = "pan_source_user";
 
     public static final String PAN_SRC_DAG = "pan_src_dag";
     public static final String PAN_SRC_EDL = "pan_src_edl";
+    public static final String PAN_TIMEOUT = "pan_timeout";
     public static final String PAN_TUNNEL_ID = "pan_tunnel_id";
     public static final String PAN_TUNNEL_STAGE = "pan_tunnel_stage";
     public static final String PAN_URL_INDEX = "pan_url_index";
+    public static final String PAN_USER_GROUP_FLAGS = "pan_user_group_flags";
     public static final String PAN_WILDFIRE_HASH = "pan_wildfire_hash";
     public static final String PAN_WILDFIRE_REPORT_ID = "pan_wildfire_report_id";
 }

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParser.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParser.java
@@ -71,7 +71,7 @@ public class PaloAlto9xParser {
             PaloAltoTypeParser parser = parsers.get(type);
             return parser.parseFields(fields);
         }
-        LOG.error("Unsupported PAN type [{}]. Not adding any parsed fields.", type);
+        LOG.info("Received log for unsupported PAN type [{}]. Will not parse.", type);
         return ImmutableMap.of();
     }
 }

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParser.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParser.java
@@ -40,7 +40,8 @@ public class PaloAlto9xParser {
                 new PaloAltoTypeParser(PaloAlto9xTemplates.hipTemplate(), PaloAltoMessageType.HIP),
                 new PaloAltoTypeParser(PaloAlto9xTemplates.systemTemplate(), PaloAltoMessageType.SYSTEM),
                 new PaloAltoTypeParser(PaloAlto9xTemplates.threatTemplate(), PaloAltoMessageType.THREAT),
-                new PaloAltoTypeParser(PaloAlto9xTemplates.trafficTemplate(), PaloAltoMessageType.TRAFFIC));
+                new PaloAltoTypeParser(PaloAlto9xTemplates.trafficTemplate(), PaloAltoMessageType.TRAFFIC),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.userIdTemplate(), PaloAltoMessageType.USERID));
     }
 
     @VisibleForTesting
@@ -51,7 +52,8 @@ public class PaloAlto9xParser {
                                            PaloAltoTypeParser hipParser,
                                            PaloAltoTypeParser systemParser,
                                            PaloAltoTypeParser threatParser,
-                                           PaloAltoTypeParser trafficParser) {
+                                           PaloAltoTypeParser trafficParser,
+                                           PaloAltoTypeParser userIdParser) {
         parsers = Maps.newHashMap();
         parsers.put(PaloAltoMessageType.CONFIG, configParser);
         parsers.put(PaloAltoMessageType.CORRELATION, correlationParser);
@@ -61,6 +63,7 @@ public class PaloAlto9xParser {
         parsers.put(PaloAltoMessageType.SYSTEM, systemParser);
         parsers.put(PaloAltoMessageType.THREAT, threatParser);
         parsers.put(PaloAltoMessageType.TRAFFIC, trafficParser);
+        parsers.put(PaloAltoMessageType.USERID, userIdParser);
     }
 
     public ImmutableMap<String, Object> parseFields(PaloAltoMessageType type, List<String> fields) {

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
@@ -17,7 +17,6 @@
 package org.graylog.integrations.inputs.paloalto9;
 
 import com.google.common.collect.Sets;
-import gov.nist.core.Host;
 import org.graylog.integrations.inputs.paloalto.PaloAltoFieldTemplate;
 import org.graylog.integrations.inputs.paloalto.PaloAltoMessageTemplate;
 import org.graylog.schema.AlertFields;

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
@@ -17,6 +17,7 @@
 package org.graylog.integrations.inputs.paloalto9;
 
 import com.google.common.collect.Sets;
+import gov.nist.core.Host;
 import org.graylog.integrations.inputs.paloalto.PaloAltoFieldTemplate;
 import org.graylog.integrations.inputs.paloalto.PaloAltoMessageTemplate;
 import org.graylog.schema.AlertFields;
@@ -574,6 +575,54 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_HIGH_RES_TIME, 102, STRING));
         fields.add(create(PaloAlto9xFields.PAN_NSDSAI_SST, 103, STRING));
         fields.add(create(PaloAlto9xFields.PAN_NSDSAI_SD, 104, STRING));
+
+        return toTemplate(fields);
+    }
+
+    public static PaloAltoMessageTemplate userIdTemplate() {
+        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+
+        // Field 0 is FUTURE USE
+        fields.add(create(EventFields.EVENT_CREATED, 1, STRING));
+        fields.add(create(EventFields.EVENT_OBSERVER_UID, 2, STRING));
+        fields.add(create(EventFields.EVENT_LOG_NAME, 3, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
+
+        // Field 5 is FUTURE USE
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(HostFields.HOST_VIRTFW_ID, 7, STRING));
+        fields.add(create(SourceFields.SOURCE_IP, 8, STRING));
+        fields.add(create(SourceFields.SOURCE_USER, 9, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_DATASOURCE_NAME, 10, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_EVENT_NAME, 11, STRING));
+        fields.add(create(EventFields.EVENT_REPEAT_COUNT, 12, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_TIMEOUT, 13, LONG));
+        fields.add(create(SourceFields.SOURCE_PORT, 14, LONG));
+
+        fields.add(create(DestinationFields.DESTINATION_PORT, 15, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_DATASOURCE, 16, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_DATASOURCE_TYPE, 17, STRING));
+        fields.add(create(EventFields.EVENT_UID, 18, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_LOG_PANORAMA, 19, STRING));
+
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_1, 20, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_2, 21, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_3, 22, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4, 23, LONG));
+        fields.add(create(HostFields.HOST_VIRTFW_HOSTNAME, 24, STRING));
+
+        fields.add(create(EventFields.EVENT_OBSERVER_HOSTNAME, 25, STRING));
+        fields.add(create(HostFields.HOST_VIRTFW_UID, 26, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_FACTOR_TYPE, 27, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_FACTOR_COMPLETION_TIME, 28, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_FACTOR_NUMBER, 29, LONG));
+
+        // Field 30 is FUTURE USE
+        // Field 31 is FUTURE USE
+        fields.add(create(PaloAlto9xFields.PAN_USER_GROUP_FLAGS, 32, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SOURCE_USER, 33, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_HIGH_RES_TIME, 34, STRING));
 
         return toTemplate(fields);
     }

--- a/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodecTest.java
+++ b/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodecTest.java
@@ -184,6 +184,19 @@ public class PaloAlto9xCodecTest {
     }
 
     @Test
+    public void decode_runsSuccessfully_whenGoodUserIdInput() {
+        givenGoodInputRawMessage();
+        givenPaloMessageType("USERID");
+        givenStoreFullMessage(false);
+        givenGoodFieldProducer();
+
+        whenDecodeIsCalled();
+
+        thenPaloParserCalledWithPaloMessageType(PaloAltoMessageType.USERID);
+        thenOutputMessageContainsExpectedFields(false);
+    }
+
+    @Test
     public void decode_returnsNull_whenRawPaloParseFails() {
         givenGoodInputRawMessage();
         givenRawParserReturnsNull();

--- a/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParserTest.java
+++ b/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParserTest.java
@@ -57,6 +57,7 @@ public class PaloAlto9xParserTest {
     @Mock PaloAltoTypeParser mockSystemParser;
     @Mock PaloAltoTypeParser mockThreatParser;
     @Mock PaloAltoTypeParser mockTrafficParser;
+    @Mock PaloAltoTypeParser mockUserIdParser;
 
     // Test Objects
     PaloAltoMessageType inputMessageType;
@@ -73,7 +74,8 @@ public class PaloAlto9xParserTest {
                 mockHipParser,
                 mockSystemParser,
                 mockThreatParser,
-                mockTrafficParser);
+                mockTrafficParser,
+                mockUserIdParser);
     }
 
     // Test Cases
@@ -174,6 +176,18 @@ public class PaloAlto9xParserTest {
     }
 
     @Test
+    public void parseFields_returnExpectedFieldMap_whenUserIdMessageType() {
+        givenInputFieldType(PaloAltoMessageType.USERID);
+        givenGoodInputFields();
+        givenGoodParsers();
+
+        whenParseFieldsIsCalled();
+
+        thenUserIdParserIsUsed();
+        thenExpectedOutputIsReturned();
+    }
+
+    @Test
     public void parseFields_returnsEmptyMap_whenNoParserFound() {
         givenInputFieldType(null);
         givenGoodInputFields();
@@ -203,6 +217,7 @@ public class PaloAlto9xParserTest {
         given(mockSystemParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
         given(mockThreatParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
         given(mockTrafficParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
+        given(mockUserIdParser.parseFields(anyList())).willReturn(TEST_FIELD_MAP);
     }
 
     // WHENs
@@ -220,6 +235,7 @@ public class PaloAlto9xParserTest {
         verifyNoMoreInteractions(mockSystemParser);
         verifyNoMoreInteractions(mockThreatParser);
         verifyNoMoreInteractions(mockTrafficParser);
+        verifyNoMoreInteractions(mockUserIdParser);
     }
 
     private void thenCorrelationParserIsUsed() {
@@ -231,6 +247,7 @@ public class PaloAlto9xParserTest {
         verifyNoMoreInteractions(mockSystemParser);
         verifyNoMoreInteractions(mockThreatParser);
         verifyNoMoreInteractions(mockTrafficParser);
+        verifyNoMoreInteractions(mockUserIdParser);
     }
 
     private void thenPre913GlobalProtectParserIsUsed() {
@@ -242,6 +259,7 @@ public class PaloAlto9xParserTest {
         verifyNoMoreInteractions(mockSystemParser);
         verifyNoMoreInteractions(mockThreatParser);
         verifyNoMoreInteractions(mockTrafficParser);
+        verifyNoMoreInteractions(mockUserIdParser);
     }
 
     private void then913GlobalProtectParserIsUsed() {
@@ -253,6 +271,7 @@ public class PaloAlto9xParserTest {
         verifyNoMoreInteractions(mockSystemParser);
         verifyNoMoreInteractions(mockThreatParser);
         verifyNoMoreInteractions(mockTrafficParser);
+        verifyNoMoreInteractions(mockUserIdParser);
     }
 
     private void thenHipParserIsUsed() {
@@ -264,6 +283,7 @@ public class PaloAlto9xParserTest {
         verifyNoMoreInteractions(mockSystemParser);
         verifyNoMoreInteractions(mockThreatParser);
         verifyNoMoreInteractions(mockTrafficParser);
+        verifyNoMoreInteractions(mockUserIdParser);
     }
 
     private void thenSystemParserIsUsed() {
@@ -275,6 +295,7 @@ public class PaloAlto9xParserTest {
         verifyNoMoreInteractions(mockHipParser);
         verifyNoMoreInteractions(mockThreatParser);
         verifyNoMoreInteractions(mockTrafficParser);
+        verifyNoMoreInteractions(mockUserIdParser);
     }
 
     private void thenThreatParserIsUsed() {
@@ -286,6 +307,7 @@ public class PaloAlto9xParserTest {
         verifyNoMoreInteractions(mockHipParser);
         verifyNoMoreInteractions(mockSystemParser);
         verifyNoMoreInteractions(mockTrafficParser);
+        verifyNoMoreInteractions(mockUserIdParser);
     }
 
     private void thenTrafficParserIsUsed() {
@@ -297,6 +319,19 @@ public class PaloAlto9xParserTest {
         verifyNoMoreInteractions(mockHipParser);
         verifyNoMoreInteractions(mockSystemParser);
         verifyNoMoreInteractions(mockThreatParser);
+        verifyNoMoreInteractions(mockUserIdParser);
+    }
+
+    private void thenUserIdParserIsUsed() {
+        ArgumentCaptor<List<String>> fieldsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mockUserIdParser, times(1)).parseFields(fieldsCaptor.capture());
+        verifyNoMoreInteractions(mockConfigParser);
+        verifyNoMoreInteractions(mockCorrelationParser);
+        verifyNoMoreInteractions(mockGlobalProtectPre913Parser);
+        verifyNoMoreInteractions(mockHipParser);
+        verifyNoMoreInteractions(mockSystemParser);
+        verifyNoMoreInteractions(mockThreatParser);
+        verifyNoMoreInteractions(mockTrafficParser);
     }
 
     private void thenNoParserUsed() {

--- a/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplatesTest.java
+++ b/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplatesTest.java
@@ -43,6 +43,9 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldTemplate.create;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.LONG;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.STRING;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -637,5 +640,61 @@ public class PaloAlto9xTemplatesTest {
          assertThat(out.getField(PaloAlto9xFields.PAN_HIGH_RES_TIME), nullValue());
          assertThat(out.getField(PaloAlto9xFields.PAN_NSDSAI_SST), nullValue());
          assertThat(out.getField(PaloAlto9xFields.PAN_NSDSAI_SD), nullValue());
+    }
+
+    @Test
+    public void verifyUserIdMessageParsing() {
+        String log = "1,2021/01/20 08:55:02,012801190281,USERID,login,2304,2021/01/20 08:55:02,vsys1,172.16.100.1,graylog-user1,,0,1,2592000,0,0,vpn-client,globalprotect,1,0x0,0,0,0,0,,PA-220,1,,2021/01/20 08:55:02,1,0x0,graylog-user1";
+        String rawMessage = SYSLOG_PREFIX + log;
+        RawMessage in = new RawMessage(rawMessage.getBytes());
+
+        Message out = cut.decode(in);
+
+        assertThat(out, notNullValue());
+        assertThat(out.getField(Message.FIELD_FULL_MESSAGE), is(rawMessage));
+        assertThat(out.getField(Message.FIELD_MESSAGE), is(log));
+        assertThat(out.getField(EventFields.EVENT_SOURCE_PRODUCT), is("PAN"));
+
+        assertThat(out.getField(EventFields.EVENT_CREATED), is("2021/01/20 08:55:02"));
+        assertThat(out.getField(EventFields.EVENT_OBSERVER_UID), is("012801190281"));
+        assertThat(out.getField(EventFields.EVENT_LOG_NAME), is("USERID"));
+
+        assertThat(out.getField(PaloAlto9xFields.PAN_LOG_SUBTYPE), is("login"));
+
+        // Field 5 is FUTURE USE - 2304
+        assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2021/01/20 08:55:02"));
+        assertThat(out.getField(HostFields.HOST_VIRTFW_ID), is("vsys1"));
+        assertThat(out.getField(SourceFields.SOURCE_IP), is("172.16.100.1"));
+        assertThat(out.getField(SourceFields.SOURCE_USER), is("graylog-user1"));
+
+        assertThat(out.getField(PaloAlto9xFields.PAN_DATASOURCE_NAME), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_EVENT_NAME), is("0"));
+        assertThat(out.getField(EventFields.EVENT_REPEAT_COUNT), is(1L));
+        assertThat(out.getField(PaloAlto9xFields.PAN_TIMEOUT), is(2592000L));
+        assertThat(out.getField(SourceFields.SOURCE_PORT), is(0L));
+
+        assertThat(out.getField(DestinationFields.DESTINATION_PORT), is(0L));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DATASOURCE), is("vpn-client"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DATASOURCE_TYPE), is("globalprotect"));
+        assertThat(out.getField(EventFields.EVENT_UID), is("1"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_LOG_PANORAMA), is("0x0"));
+
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_1), is(0L));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_2), is(0L));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_3), is(0L));
+        assertThat(out.getField(PaloAlto9xFields.PAN_DEV_GROUP_LEVEL_4), is(0L));
+        assertThat(out.getField(HostFields.HOST_VIRTFW_HOSTNAME), nullValue());
+
+        assertThat(out.getField(EventFields.EVENT_OBSERVER_HOSTNAME), is("PA-220"));
+        assertThat(out.getField(HostFields.HOST_VIRTFW_UID), is("1"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_FACTOR_TYPE), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_FACTOR_COMPLETION_TIME), is("2021/01/20 08:55:02"));
+        assertThat(out.getField(PaloAlto9xFields.PAN_FACTOR_NUMBER), is(1L));
+
+        // Field 30 is FUTURE USE - 0x0
+        // Field 31 is FUTURE USE - graylog-user1
+        assertThat(out.getField(PaloAlto9xFields.PAN_USER_GROUP_FLAGS), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_SOURCE_USER), nullValue());
+        assertThat(out.getField(PaloAlto9xFields.PAN_HIGH_RES_TIME), nullValue());
     }
 }


### PR DESCRIPTION
This change adds support for the `USERID` log type in the Palo Alto 9.x input.  This is needed for upcoming work on Graylog Illuminate.

JUnit tests have been added to ensure the new message type is handled as expected.

Note: there is currently an open question regarding the `User Group Flags` (position 32) and `User by Source` (position 32) fields in the `USERID` log type.  Per the Palo schema, positions 30 and 31 should be reserved for future use.  However, test logs obtained both from SumoLogic and from Nick's own Palo firewall seem to show `User Group Flags` in position 30 and `User by Source` in position 31.  We need to resolve this discrepancy before releasing this update.