### PR TITLE
Refactor PaloAltoTypeParser to improve performance

### DIFF
--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoCodec.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoCodec.java
@@ -34,10 +34,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.SYSTEM;
-import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.THREAT;
-import static org.graylog.integrations.inputs.paloalto.PaloAltoMessageType.TRAFFIC;
-
 public class PaloAltoCodec implements Codec {
 
     public static final String NAME = "PaloAlto";
@@ -78,15 +74,15 @@ public class PaloAltoCodec implements Codec {
 
         switch (p.panType()) {
             case "THREAT":
-                final PaloAltoTypeParser parserThreat = new PaloAltoTypeParser(templates.getThreatMessageTemplate(), THREAT);
+                final PaloAltoTypeParser parserThreat = new PaloAltoTypeParser(templates.getThreatMessageTemplate());
                 message.addFields(parserThreat.parseFields(p.fields()));
                 break;
             case "SYSTEM":
-                final PaloAltoTypeParser parserSystem = new PaloAltoTypeParser(templates.getSystemMessageTemplate(), SYSTEM);
+                final PaloAltoTypeParser parserSystem = new PaloAltoTypeParser(templates.getSystemMessageTemplate());
                 message.addFields(parserSystem.parseFields(p.fields()));
                 break;
             case "TRAFFIC":
-                final PaloAltoTypeParser parserTraffic = new PaloAltoTypeParser(templates.getTrafficMessageTemplate(), TRAFFIC);
+                final PaloAltoTypeParser parserTraffic = new PaloAltoTypeParser(templates.getTrafficMessageTemplate());
                 message.addFields(parserTraffic.parseFields(p.fields()));
                 break;
             default:

--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoFieldTemplate.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoFieldTemplate.java
@@ -19,7 +19,7 @@ package org.graylog.integrations.inputs.paloalto;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-public abstract class PaloAltoFieldTemplate {
+public abstract class PaloAltoFieldTemplate implements Comparable<PaloAltoFieldTemplate> {
     public abstract int position();
 
     public abstract String field();
@@ -28,5 +28,10 @@ public abstract class PaloAltoFieldTemplate {
 
     public static PaloAltoFieldTemplate create(String field, int position, PaloAltoFieldType fieldType) {
         return new AutoValue_PaloAltoFieldTemplate(position, field, fieldType);
+    }
+
+    @Override
+    public int compareTo(PaloAltoFieldTemplate other) {
+        return position() - other.position();
     }
 }

--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoMessageTemplate.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoMessageTemplate.java
@@ -17,9 +17,9 @@
 package org.graylog.integrations.inputs.paloalto;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 /**
  * An object representation of a PAN message template. Defines which fields to pick out from the PAN
@@ -33,15 +33,15 @@ import java.util.Set;
 
 public class PaloAltoMessageTemplate {
 
-    private Set<PaloAltoFieldTemplate> fields = new HashSet<>();
+    private SortedSet<PaloAltoFieldTemplate> fields = new TreeSet<>();
 
     private List<String> parseErrors = new ArrayList<>();
 
-    public Set<PaloAltoFieldTemplate> getFields() {
+    public SortedSet<PaloAltoFieldTemplate> getFields() {
         return fields;
     }
 
-    public void setFields(Set<PaloAltoFieldTemplate> fields) {
+    public void setFields(SortedSet<PaloAltoFieldTemplate> fields) {
         this.fields = fields;
     }
 

--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTypeParser.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTypeParser.java
@@ -35,11 +35,8 @@ public class PaloAltoTypeParser {
     private static final Logger LOG = LoggerFactory.getLogger(PaloAltoTypeParser.class);
 
     private final PaloAltoMessageTemplate messageTemplate;
-    private final PaloAltoMessageType messageType;
 
-    public PaloAltoTypeParser(PaloAltoMessageTemplate messageTemplate, PaloAltoMessageType messageType) {
-
-        this.messageType = messageType;
+    public PaloAltoTypeParser(PaloAltoMessageTemplate messageTemplate) {
         this.messageTemplate = messageTemplate;
     }
 
@@ -80,7 +77,8 @@ public class PaloAltoTypeParser {
 
                 // Handling of duplicate keys
                 if (fieldMap.containsKey(template.field())) {
-                    if (Strings.isNullOrEmpty(rawValue.trim()) || value.equals(fieldMap.get(template.field()))) {
+                    if (Strings.isNullOrEmpty(rawValue.trim()) || null == value
+                            || value.equals(fieldMap.get(template.field()))) {
                         // Same value, do nothing
                     } else if (fieldMap.get(template.field()) instanceof List) {
                         List valueList = (List) fieldMap.get(template.field());

--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTypeParser.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTypeParser.java
@@ -26,6 +26,10 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Map;
 
+import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.BOOLEAN;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.LONG;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.STRING;
+
 public class PaloAltoTypeParser {
 
     private static final Logger LOG = LoggerFactory.getLogger(PaloAltoTypeParser.class);
@@ -41,68 +45,62 @@ public class PaloAltoTypeParser {
 
     public ImmutableMap<String, Object> parseFields(List<String> fields) {
         Map<String, Object> fieldMap = Maps.newHashMap();
+        List<PaloAltoFieldTemplate> templateFields = Lists.newArrayList(messageTemplate.getFields());
 
-        for (PaloAltoFieldTemplate field : messageTemplate.getFields()) {
-            String rawValue = null;
-            try {
-                rawValue = fields.get(field.position());
-            } catch (IndexOutOfBoundsException e) {
-                // Skip fields at indexes that do not exist.
-                LOG.trace("A [{}] field does not exist at index [{}]", messageType.toString(), field.position());
+        int fieldIndex = 0;
+        int templateIndex = 0;
+
+        while (fieldIndex < fields.size() && templateIndex < templateFields.size()) {
+            String rawValue = fields.get(fieldIndex);
+            PaloAltoFieldTemplate template = templateFields.get(templateIndex);
+
+            if (fieldIndex < template.position()) {
+                fieldIndex++;
                 continue;
-            }
+            } else if (fieldIndex == template.position()) {
+                Object value = rawValue;
 
-            Object value = null;
-
-            switch (field.fieldType()) {
-                case STRING:
-                    // Handle quoted values.
+                if (template.fieldType() == STRING) {
                     if (rawValue.startsWith("\"") && rawValue.endsWith("\"")) {
-                        rawValue = rawValue.substring(1, rawValue.length() - 1);
+                        value = rawValue.substring(1, rawValue.length() - 1);
                     }
-
-                    value = rawValue;
-                    break;
-                case LONG:
-                    if (!Strings.isNullOrEmpty(rawValue)) {
-                        try {
-                            value = Long.valueOf(rawValue);
-                        } catch (NumberFormatException e) {
-                            LOG.error("[{}] is an invalid LONG value for the [{}] [{}] field", rawValue, messageType, field.field() );
-                            continue;
-                        }
-                    } else {
-                        value = 0L;
+                } else if (template.fieldType() == LONG) {
+                    try {
+                        value = Strings.isNullOrEmpty(rawValue) ? 0L : Long.valueOf(rawValue);
+                    } catch (NumberFormatException ex) {
+                        LOG.error("Error parsing field {}, {} is not a valid numeric value", template.field(), rawValue);
+                        value = null;
                     }
-                    break;
-                case BOOLEAN:
-                    if (!Strings.isNullOrEmpty(rawValue)) {
-                        value = Boolean.valueOf(rawValue);
-                    } else {
-                        value = false;
-                    }
-                    break;
-                default:
-                    throw new RuntimeException("Unhandled PAN mapping field type [" + field.fieldType() + "].");
-            }
-
-            // Handling of duplicate keys
-            if (fieldMap.containsKey(field.field())) {
-                if (Strings.isNullOrEmpty(rawValue.trim()) || value.equals(fieldMap.get(field.field()))) {
-                    // Same value, do nothing
-                    continue;
-                } else if (fieldMap.get(field.field()) instanceof List) {
-                    List valueList = (List) fieldMap.get(field.field());
-                    valueList.add(value);
-                    value = valueList;
+                } else if (template.fieldType() == BOOLEAN) {
+                    value = Boolean.valueOf(rawValue);
                 } else {
-                    List valueList = Lists.newArrayList();
-                    valueList.add(fieldMap.get(field.field()));
-                    valueList.add(value);
-                    value = valueList;
+                    LOG.warn("Unrecognized data type [{}] for field [{}], handling as STRING",
+                            template.fieldType(), template.field());
                 }
+
+                // Handling of duplicate keys
+                if (fieldMap.containsKey(template.field())) {
+                    if (Strings.isNullOrEmpty(rawValue.trim()) || value.equals(fieldMap.get(template.field()))) {
+                        // Same value, do nothing
+                    } else if (fieldMap.get(template.field()) instanceof List) {
+                        List valueList = (List) fieldMap.get(template.field());
+                        valueList.add(value);
+                        value = valueList;
+                    } else {
+                        List valueList = Lists.newArrayList();
+                        valueList.add(fieldMap.get(template.field()));
+                        valueList.add(value);
+                        value = valueList;
+                    }
+                }
+                fieldMap.put(template.field(), value);
+
+                fieldIndex++;
+                templateIndex++;
+            } else {
+                LOG.error("Not sure the template fields are properly sorted");
+                templateIndex++;
             }
-            fieldMap.put(field.field(), value);
         }
 
         return ImmutableMap.copyOf(fieldMap);

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParser.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xParser.java
@@ -33,15 +33,15 @@ public class PaloAlto9xParser {
     private final Map<PaloAltoMessageType, PaloAltoTypeParser> parsers;
 
     public PaloAlto9xParser() {
-        this(new PaloAltoTypeParser(PaloAlto9xTemplates.configTemplate(), PaloAltoMessageType.CONFIG),
-                new PaloAltoTypeParser(PaloAlto9xTemplates.correlationTemplate(), PaloAltoMessageType.CORRELATION),
-                new PaloAltoTypeParser(PaloAlto9xTemplates.globalProtectPre913Template(), PaloAltoMessageType.GLOBAL_PROTECT_PRE_9_1_3),
-                new PaloAltoTypeParser(PaloAlto9xTemplates.globalProtect913Template(), PaloAltoMessageType.GLOBAL_PROTECT_9_1_3),
-                new PaloAltoTypeParser(PaloAlto9xTemplates.hipTemplate(), PaloAltoMessageType.HIP),
-                new PaloAltoTypeParser(PaloAlto9xTemplates.systemTemplate(), PaloAltoMessageType.SYSTEM),
-                new PaloAltoTypeParser(PaloAlto9xTemplates.threatTemplate(), PaloAltoMessageType.THREAT),
-                new PaloAltoTypeParser(PaloAlto9xTemplates.trafficTemplate(), PaloAltoMessageType.TRAFFIC),
-                new PaloAltoTypeParser(PaloAlto9xTemplates.userIdTemplate(), PaloAltoMessageType.USERID));
+        this(new PaloAltoTypeParser(PaloAlto9xTemplates.configTemplate()),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.correlationTemplate()),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.globalProtectPre913Template()),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.globalProtect913Template()),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.hipTemplate()),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.systemTemplate()),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.threatTemplate()),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.trafficTemplate()),
+                new PaloAltoTypeParser(PaloAlto9xTemplates.userIdTemplate()));
     }
 
     @VisibleForTesting

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
@@ -38,7 +38,7 @@ import org.graylog.schema.UserFields;
 import org.graylog.schema.VendorFields;
 import org.graylog2.plugin.Message;
 
-import java.util.Set;
+import java.util.SortedSet;
 
 import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldTemplate.create;
 import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.LONG;
@@ -46,14 +46,14 @@ import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.STRING;
 
 public class PaloAlto9xTemplates {
 
-    private static PaloAltoMessageTemplate toTemplate(Set<PaloAltoFieldTemplate> fields) {
+    private static PaloAltoMessageTemplate toTemplate(SortedSet<PaloAltoFieldTemplate> fields) {
         PaloAltoMessageTemplate template = new PaloAltoMessageTemplate();
         template.setFields(fields);
         return template;
     }
 
     public static PaloAltoMessageTemplate configTemplate() {
-        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+        SortedSet<PaloAltoFieldTemplate> fields = Sets.newTreeSet();
 
         // Field 0 is FUTURE USE
         fields.add(create(EventFields.EVENT_CREATED, 1, STRING));
@@ -88,7 +88,7 @@ public class PaloAlto9xTemplates {
     }
 
     public static PaloAltoMessageTemplate correlationTemplate() {
-        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+        SortedSet<PaloAltoFieldTemplate> fields = Sets.newTreeSet();
 
         // Field 0 is FUTURE USE
         fields.add(create(EventFields.EVENT_CREATED, 1, STRING));
@@ -121,7 +121,7 @@ public class PaloAlto9xTemplates {
     }
 
     public static PaloAltoMessageTemplate hipTemplate() {
-        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+        SortedSet<PaloAltoFieldTemplate> fields = Sets.newTreeSet();
 
         // Field 0 is FUTURE USE
         fields.add(create(EventFields.EVENT_CREATED, 1, STRING));
@@ -165,7 +165,7 @@ public class PaloAlto9xTemplates {
     }
 
     public static PaloAltoMessageTemplate globalProtectPre913Template() {
-        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+        SortedSet<PaloAltoFieldTemplate> fields = Sets.newTreeSet();
 
         // Field 0 is FUTURE USE
         fields.add(create(EventFields.EVENT_RECEIVED_TIME, 1, STRING));
@@ -216,7 +216,7 @@ public class PaloAlto9xTemplates {
     }
 
     public static PaloAltoMessageTemplate globalProtect913Template() {
-        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+        SortedSet<PaloAltoFieldTemplate> fields = Sets.newTreeSet();
 
         // Field 0 is FUTURE USE
         fields.add(create(EventFields.EVENT_RECEIVED_TIME, 1, STRING));
@@ -272,7 +272,7 @@ public class PaloAlto9xTemplates {
     }
 
     public static PaloAltoMessageTemplate systemTemplate() {
-        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+        SortedSet<PaloAltoFieldTemplate> fields = Sets.newTreeSet();
 
         // Field 0 is FUTURE USE
         fields.add(create(EventFields.EVENT_CREATED, 1, STRING));
@@ -307,7 +307,7 @@ public class PaloAlto9xTemplates {
     }
 
     public static PaloAltoMessageTemplate threatTemplate() {
-        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+        SortedSet<PaloAltoFieldTemplate> fields = Sets.newTreeSet();
 
         // Field 0 is FUTURE USE
         fields.add(create(EventFields.EVENT_RECEIVED_TIME, 1, STRING));
@@ -447,7 +447,7 @@ public class PaloAlto9xTemplates {
     }
 
     public static PaloAltoMessageTemplate trafficTemplate() {
-        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+        SortedSet<PaloAltoFieldTemplate> fields = Sets.newTreeSet();
 
         // Field 0 is FUTURE USE
         fields.add(create(EventFields.EVENT_RECEIVED_TIME, 1, STRING));
@@ -579,7 +579,7 @@ public class PaloAlto9xTemplates {
     }
 
     public static PaloAltoMessageTemplate userIdTemplate() {
-        Set<PaloAltoFieldTemplate> fields = Sets.newHashSet();
+        SortedSet<PaloAltoFieldTemplate> fields = Sets.newTreeSet();
 
         // Field 0 is FUTURE USE
         fields.add(create(EventFields.EVENT_CREATED, 1, STRING));


### PR DESCRIPTION
As documented in #726, a customer reported perfomrance issues with the Palo 9.x input.  

This change is an attempt to improve Palo input parse times by ensuring the Palo template fields are ordered by position and iterating over the input string from beginning to end rather than going through the unordered template fields and essentially doing random access on the input string.

Verified that the changes do not break existing Palo JUnits.  Also tested locally with the data driver script and sample Palo log files.