### PR TITLE
Hide global input option for AWS on cloud

### DIFF
--- a/src/web/aws/cloudwatch/FormAdvancedOptions.jsx
+++ b/src/web/aws/cloudwatch/FormAdvancedOptions.jsx
@@ -22,6 +22,7 @@ import { Input } from 'components/bootstrap';
 import { FormDataContext } from 'aws/context/FormData';
 import { AdvancedOptionsContext } from 'aws/context/AdvancedOptions';
 import AdditionalFields from 'aws/common/AdditionalFields';
+import HideOnCloud from 'util/conditional/HideOnCloud';
 
 const FormAdvancedOptions = ({ onChange }) => {
   const { formData } = useContext(FormDataContext);
@@ -40,13 +41,15 @@ const FormAdvancedOptions = ({ onChange }) => {
 
   return (
     <StyledAdditionalFields title="Advanced Options" visible={isAdvancedOptionsVisible} onToggle={handleToggle}>
-      <Input id="awsCloudWatchGlobalInput"
-             type="checkbox"
-             value="global-input"
-             defaultChecked={awsCloudWatchGlobalInput ? awsCloudWatchGlobalInput.value : ''}
-             onChange={onChange}
-             label="Global Input"
-             help="Should this input start on all nodes" />
+      <HideOnCloud>
+        <Input id="awsCloudWatchGlobalInput"
+               type="checkbox"
+               value="global-input"
+               defaultChecked={awsCloudWatchGlobalInput ? awsCloudWatchGlobalInput.value : ''}
+               onChange={onChange}
+               label="Global Input"
+               help="Should this input start on all nodes" />
+      </HideOnCloud>
 
       <Input id="awsCloudWatchThrottleEnabled"
              type="checkbox"

--- a/src/web/aws/cloudwatch/StepReview.jsx
+++ b/src/web/aws/cloudwatch/StepReview.jsx
@@ -28,6 +28,7 @@ import useFetch from 'aws/common/hooks/useFetch';
 import FormWrap from 'aws/common/FormWrap';
 import { ApiRoutes } from 'aws/common/Routes';
 import { DEFAULT_KINESIS_LOG_TYPE, KINESIS_LOG_TYPES } from 'aws/common/constants';
+import HideOnCloud from 'util/conditional/HideOnCloud';
 
 const Default = ({ value }) => (
   <>{value} <small>(default)</small></>
@@ -175,10 +176,12 @@ const StepReview = ({ onSubmit, onEditClick, externalInputSubmit }) => {
             <strong>Stream</strong>
             <span>{awsCloudWatchKinesisStream.value}</span>
           </li>
-          <li>
-            <strong>Global Input</strong>
-            <span><Icon name={globalInputEnabled ? 'check' : 'times'} /></span>
-          </li>
+          <HideOnCloud>
+            <li>
+              <strong>Global Input</strong>
+              <span><Icon name={globalInputEnabled ? 'check' : 'times'} /></span>
+            </li>
+          </HideOnCloud>
           <li>
             <strong>Record Batch Size</strong>
             <span>


### PR DESCRIPTION
As described here: https://github.com/Graylog2/graylog-plugin-cloud/issues/763

We need to hide the global input option on cloud instances.