### PR TITLE
Ensure PAN timestamps are DateTime not String (#816) (#825)

### DIFF
--- a/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplatesTest.java
+++ b/src/test/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplatesTest.java
@@ -38,6 +38,7 @@ import org.graylog.schema.VendorFields;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.journal.RawMessage;
+import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -83,7 +84,7 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(HostFields.HOST_ID), is("007000000018919"));
         assertThat(out.getField(EventFields.EVENT_LOG_NAME), is("CONFIG"));
         assertThat(out.getField(PaloAlto9xFields.PAN_LOG_SUBTYPE), is("0"));
-        assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2020/05/26 04:11:09"));
+        assertThat(out.getField(Message.FIELD_TIMESTAMP), is(DateTime.parse("2020-05-26T04:11:09Z")));
         assertThat(out.getField(SourceFields.SOURCE_REFERENCE), is("86.181.133.251"));
         assertThat(out.getField(HostFields.HOST_VIRTFW_ID), nullValue());
         assertThat(out.getField(UserFields.USER_COMMAND), is("multi-clone"));
@@ -120,7 +121,7 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(HostFields.HOST_ID), is("0007SE00209"));
         assertThat(out.getField(EventFields.EVENT_LOG_NAME), is("CORRELATION"));
         assertThat(out.getField(PaloAlto9xFields.PAN_LOG_SUBTYPE), nullValue());
-        assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2020/05/31 17:19:44"));
+        assertThat(out.getField(Message.FIELD_TIMESTAMP), is(DateTime.parse("2020-05-31T17:19:44Z")));
         assertThat(out.getField(SourceFields.SOURCE_IP), is("10.154.8.125"));
         assertThat(out.getField(UserFields.USER_NAME), is("pancademo\\david.mccoy"));
         assertThat(out.getField(HostFields.HOST_VIRTFW_ID), nullValue());
@@ -156,7 +157,7 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(EventFields.EVENT_UID), is("11"));
         assertThat(out.getField(PaloAlto9xFields.PAN_LOG_PANORAMA), is("0x0"));
         assertThat(out.getField(EventFields.EVENT_LOG_NAME), is("GLOBALPROTECT"));
-        assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2020/04/01 10:49:35"));
+        assertThat(out.getField(Message.FIELD_TIMESTAMP), is(DateTime.parse("2020-04-01T10:49:35Z")));
         assertThat(out.getField(HostFields.HOST_VIRTFW_ID), is("vsys1"));
         assertThat(out.getField(PaloAlto9xFields.PAN_EVENT_NAME), is("portal-prelogin"));
         assertThat(out.getField(PaloAlto9xFields.PAN_TUNNEL_STAGE), is("before-login"));
@@ -201,7 +202,7 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(EventFields.EVENT_RECEIVED_TIME), is("2020/04/01 10:49:35"));
         assertThat(out.getField(HostFields.HOST_ID), is("015351000040055"));
         assertThat(out.getField(EventFields.EVENT_LOG_NAME), is("GLOBALPROTECT"));
-        assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2020/04/01 10:49:35"));
+        assertThat(out.getField(Message.FIELD_TIMESTAMP), is(DateTime.parse("2020-04-01T10:49:35Z")));
         assertThat(out.getField(HostFields.HOST_VIRTFW_ID), is("vsys1"));
         assertThat(out.getField(PaloAlto9xFields.PAN_EVENT_NAME), is("portal-prelogin"));
         assertThat(out.getField(PaloAlto9xFields.PAN_TUNNEL_STAGE), is("before-login"));
@@ -255,7 +256,7 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(EventFields.EVENT_OBSERVER_UID), nullValue());
         assertThat(out.getField(EventFields.EVENT_LOG_NAME), is("HIPMATCH"));
         assertThat(out.getField(PaloAlto9xFields.PAN_LOG_SUBTYPE), is("0"));
-        assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2020/03/18 04:02:55"));
+        assertThat(out.getField(Message.FIELD_TIMESTAMP), is(DateTime.parse("2020-03-18T04:02:55Z")));
         assertThat(out.getField(UserFields.USER_NAME), is("user1@prismaissase.com"));
         assertThat(out.getField(HostFields.HOST_VIRTFW_ID), is("vsys1"));
         assertThat(out.getField(HostFields.HOST_HOSTNAME), is("DFWMACW12KG8WL"));
@@ -297,7 +298,7 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(HostFields.HOST_ID), is("007000016479"));
         assertThat(out.getField(EventFields.EVENT_LOG_NAME), is("SYSTEM"));
         assertThat(out.getField(PaloAlto9xFields.PAN_LOG_SUBTYPE), is("general"));
-        assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2020/03/19 10:12:57"));
+        assertThat(out.getField(Message.FIELD_TIMESTAMP), is(DateTime.parse("2020-03-19T10:12:57Z")));
         assertThat(out.getField(HostFields.HOST_VIRTFW_ID), nullValue());
         assertThat(out.getField(PaloAlto9xFields.PAN_EVENT_NAME), is("general"));
         assertThat(out.getField(PaloAlto9xFields.PAN_EVENT_OBJECT), nullValue());
@@ -335,7 +336,7 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(PaloAlto9xFields.PAN_LOG_SUBTYPE), is("spyware"));
 
         // Field 5 is FUTURE USE
-        assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2020/05/19 07:37:27"));
+        assertThat(out.getField(Message.FIELD_TIMESTAMP), is(DateTime.parse("2020-05-19T07:37:27Z")));
         assertThat(out.getField(SourceFields.SOURCE_IP), is("10.154.229.167"));
         assertThat(out.getField(DestinationFields.DESTINATION_IP), is("190.253.254.254"));
         assertThat(out.getField(SourceFields.SOURCE_NAT_IP), nullValue());
@@ -522,7 +523,7 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(PaloAlto9xFields.PAN_LOG_SUBTYPE), is("end"));
 
         // Field 5 is FUTURE USE
-        assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2020/05/19 07:34:54"));
+        assertThat(out.getField(Message.FIELD_TIMESTAMP), is(DateTime.parse("2020-05-19T07:34:54Z")));
         assertThat(out.getField(SourceFields.SOURCE_IP), is("10.154.172.134"));
         assertThat(out.getField(DestinationFields.DESTINATION_IP), is("151.151.88.132"));
         assertThat(out.getField(SourceFields.SOURCE_NAT_IP), nullValue());
@@ -662,7 +663,7 @@ public class PaloAlto9xTemplatesTest {
         assertThat(out.getField(PaloAlto9xFields.PAN_LOG_SUBTYPE), is("login"));
 
         // Field 5 is FUTURE USE - 2304
-        assertThat(out.getField(Message.FIELD_TIMESTAMP), is("2021/01/20 08:55:02"));
+        assertThat(out.getField(Message.FIELD_TIMESTAMP), is(DateTime.parse("2021-01-20T08:55:02Z")));
         assertThat(out.getField(HostFields.HOST_VIRTFW_ID), is("vsys1"));
         assertThat(out.getField(SourceFields.SOURCE_IP), is("172.16.100.1"));
         assertThat(out.getField(SourceFields.SOURCE_USER), is("graylog-user1"));


### PR DESCRIPTION
This is a backport of #825 to the 4.0 branch for the next bugfix release.  Please see original PR for more details.