### PR TITLE
Only validate Slack Notif webhook URL if it is a Slack or Discord URL

### DIFF
--- a/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigTest.java
@@ -28,9 +28,11 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 
 public class SlackEventNotificationConfigTest {
@@ -84,8 +86,8 @@ public class SlackEventNotificationConfigTest {
         assertThat(result.failed()).isTrue();
         Map errors = result.getErrors();
         assertThat(errors).size().isEqualTo(1);
-        assertThat(errors.get(SlackEventNotificationConfig.FIELD_WEBHOOK_URL)
-                .equals(SlackEventNotificationConfig.INVALID_WEBHOOK_ERROR_MESSAGE));
+        assertEquals(((List)errors.get(SlackEventNotificationConfig.FIELD_WEBHOOK_URL)).get(0),
+                SlackEventNotificationConfig.INVALID_WEBHOOK_ERROR_MESSAGE);
     }
 
     @Test
@@ -97,8 +99,8 @@ public class SlackEventNotificationConfigTest {
         assertThat(result.failed()).isTrue();
         Map errors = result.getErrors();
         assertThat(errors).size().isEqualTo(1);
-        assertThat(errors.get(SlackEventNotificationConfig.FIELD_WEBHOOK_URL)
-                .equals(SlackEventNotificationConfig.INVALID_SLACK_URL_ERROR_MESSAGE));
+        assertEquals(((List)errors.get(SlackEventNotificationConfig.FIELD_WEBHOOK_URL)).get(0),
+                SlackEventNotificationConfig.INVALID_SLACK_URL_ERROR_MESSAGE);
     }
 
     @Test
@@ -110,8 +112,8 @@ public class SlackEventNotificationConfigTest {
         assertThat(result.failed()).isTrue();
         Map errors = result.getErrors();
         assertThat(errors).size().isEqualTo(1);
-        assertThat(errors.get(SlackEventNotificationConfig.FIELD_WEBHOOK_URL)
-                .equals(SlackEventNotificationConfig.INVALID_DISCORD_URL_ERROR_MESSAGE));
+        assertEquals(((List)errors.get(SlackEventNotificationConfig.FIELD_WEBHOOK_URL)).get(0),
+                SlackEventNotificationConfig.INVALID_DISCORD_URL_ERROR_MESSAGE);
     }
 
     @Test

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigTest.java
@@ -36,6 +36,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SlackEventNotificationConfigTest {
 
     @Test
+    public void validate_succeeds_whenWebhookUrlIsValidUrl() {
+        SlackEventNotificationConfig slackEventNotificationConfig = SlackEventNotificationConfig.builder()
+                .webhookUrl("http://graylog.org")
+                .build();
+        ValidationResult result = slackEventNotificationConfig.validate();
+        Map errors = result.getErrors();
+        assertThat(errors).size().isEqualTo(0);
+    }
+
+    @Test
     public void validate_succeeds_whenWebhookUrlIsValidSlackUrl() {
         SlackEventNotificationConfig slackEventNotificationConfig = SlackEventNotificationConfig.builder()
                 .webhookUrl("https://hooks.slack.com/services/xxxx/xxxx/xxxxxxx")
@@ -68,12 +78,40 @@ public class SlackEventNotificationConfigTest {
     @Test
     public void validate_failsAndReturnsAnError_whenWebhookUrlIsInvalid() {
         SlackEventNotificationConfig slackEventNotificationConfig = SlackEventNotificationConfig.builder()
-                .webhookUrl("A67888900000")
+                .webhookUrl("html:/?Thing.foo")
                 .build();
         ValidationResult result = slackEventNotificationConfig.validate();
         assertThat(result.failed()).isTrue();
         Map errors = result.getErrors();
-        assertThat(errors).size().isGreaterThan(0);
+        assertThat(errors).size().isEqualTo(1);
+        assertThat(errors.get(SlackEventNotificationConfig.FIELD_WEBHOOK_URL)
+                .equals(SlackEventNotificationConfig.INVALID_WEBHOOK_ERROR_MESSAGE));
+    }
+
+    @Test
+    public void validate_failsAndReturnsAnError_whenWebhookUrlIsInvalidSlackUrl() {
+        SlackEventNotificationConfig slackEventNotificationConfig = SlackEventNotificationConfig.builder()
+                .webhookUrl("https://hooks.slack.com/api/foo")
+                .build();
+        ValidationResult result = slackEventNotificationConfig.validate();
+        assertThat(result.failed()).isTrue();
+        Map errors = result.getErrors();
+        assertThat(errors).size().isEqualTo(1);
+        assertThat(errors.get(SlackEventNotificationConfig.FIELD_WEBHOOK_URL)
+                .equals(SlackEventNotificationConfig.INVALID_SLACK_URL_ERROR_MESSAGE));
+    }
+
+    @Test
+    public void validate_failsAndReturnsAnError_whenWebhookUrlIsInvalidDiscordUrl() {
+        SlackEventNotificationConfig slackEventNotificationConfig = SlackEventNotificationConfig.builder()
+                .webhookUrl("https://discord.com/api/webhooks/xxxx/xxXXXxxxxxxxxx")
+                .build();
+        ValidationResult result = slackEventNotificationConfig.validate();
+        assertThat(result.failed()).isTrue();
+        Map errors = result.getErrors();
+        assertThat(errors).size().isEqualTo(1);
+        assertThat(errors.get(SlackEventNotificationConfig.FIELD_WEBHOOK_URL)
+                .equals(SlackEventNotificationConfig.INVALID_DISCORD_URL_ERROR_MESSAGE));
     }
 
     @Test


### PR DESCRIPTION
Per #835, the Slack Notification plugin is currently only allowing Slack and Discord webhook URLs when there are other messaging systems capable of accepting Slack-formatted input.  This change updates the Slack Notification plugin to do basic URL validation on provided webhook URLs unless those URLs include "slack" or "discord" in the domain name.  Webhook URLs with "slack" or "discord" in the domain name, will be further validated against the existing Slack/Discord patterns.

JUnit test has been updated to cover all new cases.