### PR TITLE
Parse timestamps in PaloAltoTypeParser

### DIFF
--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoFieldType.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoFieldType.java
@@ -17,5 +17,5 @@
 package org.graylog.integrations.inputs.paloalto;
 
 public enum PaloAltoFieldType {
-       STRING, LONG, BOOLEAN
+       STRING, LONG, BOOLEAN, TIMESTAMP
 }

--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTypeParser.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoTypeParser.java
@@ -20,6 +20,10 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,10 +33,12 @@ import java.util.Map;
 import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.BOOLEAN;
 import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.LONG;
 import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.STRING;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.TIMESTAMP;
 
 public class PaloAltoTypeParser {
 
     private static final Logger LOG = LoggerFactory.getLogger(PaloAltoTypeParser.class);
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormat.forPattern("yyyy/MM/dd HH:mm:ssZZ");
 
     private final PaloAltoMessageTemplate messageTemplate;
 
@@ -70,6 +76,18 @@ public class PaloAltoTypeParser {
                     }
                 } else if (template.fieldType() == BOOLEAN) {
                     value = Boolean.valueOf(rawValue);
+                } else if (template.fieldType() == TIMESTAMP) {
+                    String stringValue = rawValue;
+                    if (rawValue.startsWith("\"") && rawValue.endsWith("\"")) {
+                        stringValue = rawValue.substring(1, rawValue.length() - 1);
+                    }
+                    if (!Strings.isNullOrEmpty(stringValue)) {
+                        try {
+                            value = DateTime.parse(stringValue + "Z", DATE_TIME_FORMATTER).withZone(DateTimeZone.UTC);
+                        } catch (Exception e) {
+                            LOG.debug("Error parsing field {}, {} is not a valid timestamp value", template.field(), stringValue, e);
+                        }
+                    }
                 } else {
                     LOG.warn("Unrecognized data type [{}] for field [{}], handling as STRING",
                             template.fieldType(), template.field());
@@ -91,7 +109,9 @@ public class PaloAltoTypeParser {
                         value = valueList;
                     }
                 }
-                fieldMap.put(template.field(), value);
+                if (value != null) {
+                    fieldMap.put(template.field(), value);
+                }
 
                 fieldIndex++;
                 templateIndex++;

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodec.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodec.java
@@ -30,10 +30,6 @@ import org.graylog2.plugin.inputs.annotations.FactoryClass;
 import org.graylog2.plugin.inputs.codecs.Codec;
 import org.graylog2.plugin.inputs.codecs.CodecAggregator;
 import org.graylog2.plugin.journal.RawMessage;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +51,6 @@ public class PaloAlto9xCodec implements Codec {
     private static final Logger LOG = LoggerFactory.getLogger(PaloAlto9xCodec.class);
 
     static final String CK_STORE_FULL_MESSAGE = "store_full_message";
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormat.forPattern("yyyy/MM/dd HH:mm:ssZZ");
 
     public static final String NAME = "PaloAlto9x";
 
@@ -123,7 +118,6 @@ public class PaloAlto9xCodec implements Codec {
         }
 
         message.addField(EventFields.EVENT_SOURCE_PRODUCT, "PAN");
-        fixTimestampField(message);
 
         // Store full message if configured.
         if (configuration.getBoolean(CK_STORE_FULL_MESSAGE)) {
@@ -182,14 +176,5 @@ public class PaloAlto9xCodec implements Codec {
     @Override
     public CodecAggregator getAggregator() {
         return null;
-    }
-
-    private void fixTimestampField(Message message) {
-        Object timestampObj = message.getField(Message.FIELD_TIMESTAMP);
-        if (timestampObj instanceof String) {
-            String timestampString = timestampObj + "Z";
-            DateTime parsedTimestamp = DateTime.parse(timestampString, DATE_TIME_FORMATTER).withZone(DateTimeZone.UTC);
-            message.addField(Message.FIELD_TIMESTAMP, parsedTimestamp);
-        }
     }
 }

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
@@ -43,6 +43,7 @@ import java.util.SortedSet;
 import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldTemplate.create;
 import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.LONG;
 import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.STRING;
+import static org.graylog.integrations.inputs.paloalto.PaloAltoFieldType.TIMESTAMP;
 
 public class PaloAlto9xTemplates {
 
@@ -62,7 +63,7 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
 
         // Field 5 is FUTURE USE
-        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, TIMESTAMP));
         fields.add(create(SourceFields.SOURCE_REFERENCE, 7, STRING));
         fields.add(create(HostFields.HOST_VIRTFW_ID, 8, STRING));
         fields.add(create(UserFields.USER_COMMAND, 9, STRING));
@@ -97,7 +98,7 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
 
         // Field 5 is FUTURE USE
-        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, TIMESTAMP));
         fields.add(create(SourceFields.SOURCE_IP, 7, STRING));
         fields.add(create(UserFields.USER_NAME, 8, STRING));
         fields.add(create(HostFields.HOST_VIRTFW_ID, 9, STRING));
@@ -130,7 +131,7 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
 
         // Field 5 is FUTURE USE
-        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, TIMESTAMP));
         fields.add(create(UserFields.USER_NAME, 7, STRING));
         fields.add(create(HostFields.HOST_VIRTFW_ID, 8, STRING));
         fields.add(create(HostFields.HOST_HOSTNAME, 9, STRING));
@@ -176,7 +177,7 @@ public class PaloAlto9xTemplates {
         fields.add(create(EventFields.EVENT_LOG_NAME, 5, STRING));
         // Field 6 is FUTURE USE
         // Field 7 is FUTURE USE
-        fields.add(create(Message.FIELD_TIMESTAMP, 8, STRING));
+        fields.add(create(Message.FIELD_TIMESTAMP, 8, TIMESTAMP));
         fields.add(create(HostFields.HOST_VIRTFW_ID, 9, STRING));
 
         fields.add(create(PaloAlto9xFields.PAN_EVENT_NAME, 10, STRING));
@@ -225,7 +226,7 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
 
         // Field 5 is FUTURE USE
-        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, TIMESTAMP));
         fields.add(create(HostFields.HOST_VIRTFW_ID, 7, STRING));
         fields.add(create(PaloAlto9xFields.PAN_EVENT_NAME, 8, STRING));
         fields.add(create(PaloAlto9xFields.PAN_TUNNEL_STAGE, 9, STRING));
@@ -281,7 +282,7 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
 
         // Field 5 is FUTURE USE
-        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, TIMESTAMP));
         fields.add(create(HostFields.HOST_VIRTFW_ID, 7, STRING));
         fields.add(create(PaloAlto9xFields.PAN_EVENT_NAME, 8, STRING));
         fields.add(create(PaloAlto9xFields.PAN_EVENT_OBJECT, 9, STRING));
@@ -316,7 +317,7 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
 
         // Field 5 is FUTURE USE
-        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, TIMESTAMP));
         fields.add(create(SourceFields.SOURCE_IP, 7, STRING));
         fields.add(create(DestinationFields.DESTINATION_IP, 8, STRING));
         fields.add(create(SourceFields.SOURCE_NAT_IP, 9, STRING));
@@ -456,7 +457,7 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
 
         // Field 5 is FUTURE USE
-        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, TIMESTAMP));
         fields.add(create(SourceFields.SOURCE_IP, 7, STRING));
         fields.add(create(DestinationFields.DESTINATION_IP, 8, STRING));
         fields.add(create(SourceFields.SOURCE_NAT_IP, 9, STRING));
@@ -588,7 +589,7 @@ public class PaloAlto9xTemplates {
         fields.add(create(PaloAlto9xFields.PAN_LOG_SUBTYPE, 4, STRING));
 
         // Field 5 is FUTURE USE
-        fields.add(create(Message.FIELD_TIMESTAMP, 6, STRING));
+        fields.add(create(Message.FIELD_TIMESTAMP, 6, TIMESTAMP));
         fields.add(create(HostFields.HOST_VIRTFW_ID, 7, STRING));
         fields.add(create(SourceFields.SOURCE_IP, 8, STRING));
         fields.add(create(SourceFields.SOURCE_USER, 9, STRING));


### PR DESCRIPTION
This moves the timestamp parsing to an earlier stage in the processing,
and avoids setting an intermediate String to a Message timestamp field.

The changes introduced in
 https://github.com/Graylog2/graylog2-server/pull/11149
are replacing unparseable timestamps with the current time.
Thus the previous approach of fixTimestampField() will not
find the earlier set String timestamp anymore.

Refs https://github.com/Graylog2/graylog-plugin-integrations/pull/825

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

