### PR TITLE
Make slack channel name templatable

### DIFF
--- a/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotification.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotification.java
@@ -117,12 +117,14 @@ public class SlackEventNotification implements EventNotification {
             customMessage = buildCustomMessage(ctx, config, template);
         }
 
+        String templatedChannel = buildTemplatedChannel(ctx, config, config.channel());
+
         return new SlackMessage(
                 config.color(),
                 config.iconEmoji(),
                 config.iconUrl(),
                 config.userName(),
-                config.channel(),
+                templatedChannel,
                 linkNames,
                 message,
                 customMessage
@@ -143,14 +145,27 @@ public class SlackEventNotification implements EventNotification {
         return "_" + eventDefinitionName + "_";
     }
 
+    String buildTemplatedChannel(EventNotificationContext ctx, SlackEventNotificationConfig config, String template) throws PermanentEventNotificationException {
+        final List<MessageSummary> backlog = getMessageBacklog(ctx, config);
+        Map<String, Object> model = getCustomMessageModel(ctx, config.type(), backlog);
+        try {
+            LOG.debug("channel: template = {} model = {}", template, model);
+            return templateEngine.transform(template, model);
+        } catch (Exception e) {
+            String error = "Invalid channel template.";
+            LOG.error(error + "[{}]", e.toString());
+            throw new PermanentEventNotificationException(error + e.toString(), e.getCause());
+        }
+    }
+
     String buildCustomMessage(EventNotificationContext ctx, SlackEventNotificationConfig config, String template) throws PermanentEventNotificationException {
         final List<MessageSummary> backlog = getMessageBacklog(ctx, config);
         Map<String, Object> model = getCustomMessageModel(ctx, config.type(), backlog);
         try {
-            LOG.debug("template = {} model = {}", template, model);
+            LOG.debug("customMessage: template = {} model = {}", template, model);
             return templateEngine.transform(template, model);
         } catch (Exception e) {
-            String error = "Invalid Custom Message template.";
+            String error = "Invalid channel name template.";
             LOG.error(error + "[{}]", e.toString());
             throw new PermanentEventNotificationException(error + e.toString(), e.getCause());
         }


### PR DESCRIPTION
We have support teams in different countries that follow dedicated slack channels. Slack channel names can be automatically derived from the same data as the custom message can. As of now we have to create an alerting rule per country where we could have just one rule. This PR implements templating the channel name using the same model as the custom message. 