### PR TITLE
Upgrade aws-java-sdk to fix IRSA on EKS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.site.skip>true</maven.site.skip>
         <graylog.version>4.3.0-SNAPSHOT</graylog.version>
-        <aws-java-sdk-2.version>2.13.6</aws-java-sdk-2.version>
+        <aws-java-sdk-2.version>2.17.77</aws-java-sdk-2.version>
         <aws-kinesis-client.version>2.2.10</aws-kinesis-client.version>
         <integrations.protobuf.version>3.11.1</integrations.protobuf.version>
     </properties>
@@ -232,6 +232,7 @@
                                 <include>software/amazon/awssdk/regions/**</include>
                                 <include>software/amazon/awssdk/thirdparty/**</include>
                                 <include>software/amazon/awssdk/utils/**</include>
+                                <include>software/amazon/awssdk/metrics/**</include>
                                 <!-- Include only the specific service packages that are needed. -->
                                 <include>software/amazon/awssdk/services/cloudwatchlogs/**</include>
                                 <include>software/amazon/awssdk/services/dynamodb/**</include>

--- a/src/test/java/org/graylog/integrations/aws/service/AWSServiceTest.java
+++ b/src/test/java/org/graylog/integrations/aws/service/AWSServiceTest.java
@@ -142,8 +142,8 @@ public class AWSServiceTest {
         assertTrue(foundEuWestRegion);
 
         // Use none liner presence checks.
-        assertTrue(regions.stream().anyMatch(r -> r.displayValue().equals("EU (Stockholm): eu-north-1")));
-        assertEquals("There should be 26 total regions. This will change in future versions of the AWS SDK", 26, regions.size());
+        assertTrue(regions.stream().anyMatch(r -> r.displayValue().equals("Europe (Stockholm): eu-north-1")));
+        assertEquals("There should be 28 total regions. This will change in future versions of the AWS SDK", 28, regions.size());
     }
 
     @Test


### PR DESCRIPTION
This fixes #722 by upgrading the aws-java-sdk to the newest version.

For others, remember to set the following in helm chart to allow the aws-java-sdk to read the token file (from `AWS_WEB_IDENTITY_TOKEN_FILE`):
```
graylog:
  podSecurityContext:
    fsGroup: 1100
```

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging