### PR TITLE
Renames OS GreyNoise adapter and adds User-Agent header

### DIFF
--- a/src/main/java/org/graylog/integrations/IntegrationsModule.java
+++ b/src/main/java/org/graylog/integrations/IntegrationsModule.java
@@ -26,7 +26,7 @@ import org.graylog.integrations.aws.resources.AWSResource;
 import org.graylog.integrations.aws.resources.KinesisSetupResource;
 import org.graylog.integrations.aws.transports.AWSTransport;
 import org.graylog.integrations.aws.transports.KinesisTransport;
-import org.graylog.integrations.dataadapters.GreyNoiseDataAdapter;
+import org.graylog.integrations.dataadapters.GreyNoiseQuickIPDataAdapter;
 import org.graylog.integrations.inputs.paloalto.PaloAltoCodec;
 import org.graylog.integrations.inputs.paloalto.PaloAltoTCPInput;
 import org.graylog.integrations.inputs.paloalto9.PaloAlto9xCodec;
@@ -111,10 +111,10 @@ public class IntegrationsModule extends PluginModule {
                     PagerDutyNotification.Factory.class);
 
             // GreyNoise Data Adapter
-            installLookupDataAdapter(GreyNoiseDataAdapter.NAME,
-                                     GreyNoiseDataAdapter.class,
-                                     GreyNoiseDataAdapter.Factory.class,
-                                     GreyNoiseDataAdapter.Config.class);
+            installLookupDataAdapter(GreyNoiseQuickIPDataAdapter.NAME,
+                    GreyNoiseQuickIPDataAdapter.class,
+                    GreyNoiseQuickIPDataAdapter.Factory.class,
+                    GreyNoiseQuickIPDataAdapter.Config.class);
         }
     }
 

--- a/src/test/java/org/graylog/integrations/dataadapters/GreyNoiseDataAdapterTest.java
+++ b/src/test/java/org/graylog/integrations/dataadapters/GreyNoiseDataAdapterTest.java
@@ -59,7 +59,7 @@ public class GreyNoiseDataAdapterTest {
     public void parseBodyWithMultiValue(){
         getvalidResponse();
 
-        final LookupResult result = GreyNoiseDataAdapter.parseResponse(mockResponse);
+        final LookupResult result = GreyNoiseQuickIPDataAdapter.parseResponse(mockResponse);
         assertThat(result, notNullValue());
         Assertions.assertThat(result.isEmpty()).isFalse();
         Assertions.assertThat(result.hasError()).isFalse();

--- a/src/web/dataadapters/GreyNoiseAdapterDocumentation.jsx
+++ b/src/web/dataadapters/GreyNoiseAdapterDocumentation.jsx
@@ -25,7 +25,7 @@ class GreyNoiseAdapterDocumentation extends React.Component {
     return (
       <div>
         <p style={style}>
-            The Greynoise data adapter uses the <ExternalLink href="https://developer.greynoise.io/">Greynoise API</ExternalLink> to
+            The GreyNoise Quick IP Lookup data adapter uses the <ExternalLink href="https://developer.greynoise.io/">Greynoise API</ExternalLink> to
             lookup indicators for the given key and returns the values for the  IP Quick Context endpoint.
             See <ExternalLink href="https://developer.greynoise.io/reference/ip-lookup-1#quickcheck-1">IP Quick Context</ExternalLink>
         </p>

--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -67,7 +67,7 @@ const manifest = new PluginManifest(packageJson, {
   lookupTableAdapters: [
     {
       type: 'GreyNoise',
-      displayName: 'GreyNoise',
+      displayName: 'GreyNoise Quick IP Lookup',
       formComponent: GreyNoiseAdapterFieldSet,
       summaryComponent: GreyNoiseAdapterSummary,
       documentationComponent: GreyNoiseAdapterDocumentation,


### PR DESCRIPTION
- Renames GreyNoise Data Adapter to GreyNoise Quick IP Lookup 
- Adds generic "Graylog/Version" User-Agent header to GreyNoise API call - open to suggestions on what else to add to that header

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

