### PR TITLE
Disabling auto-rebasing for dependabot PRs.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,11 @@ updates:
     interval: daily
     time: "11:00"
   open-pull-requests-limit: 10
+  rebase-strategy: "disabled"
 - package-ecosystem: maven
   directory: "/"
   schedule:
     interval: daily
     time: "11:00"
   open-pull-requests-limit: 10
+  rebase-strategy: "disabled"


### PR DESCRIPTION
This change is disabling auto-rebasing of dependency update PRs created by dependabot.