### PR TITLE
Bump aws sdk to 2.17.213

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.site.skip>true</maven.site.skip>
         <graylog.version>4.4.0-SNAPSHOT</graylog.version>
-        <aws-java-sdk-2.version>2.17.77</aws-java-sdk-2.version>
+        <aws-java-sdk-2.version>2.17.213</aws-java-sdk-2.version>
         <aws-kinesis-client.version>2.2.10</aws-kinesis-client.version>
         <integrations.protobuf.version>3.11.1</integrations.protobuf.version>
     </properties>

--- a/src/test/java/org/graylog/integrations/aws/service/AWSServiceTest.java
+++ b/src/test/java/org/graylog/integrations/aws/service/AWSServiceTest.java
@@ -143,7 +143,7 @@ public class AWSServiceTest {
 
         // Use none liner presence checks.
         assertTrue(regions.stream().anyMatch(r -> r.displayValue().equals("Europe (Stockholm): eu-north-1")));
-        assertEquals("There should be 28 total regions. This will change in future versions of the AWS SDK", 28, regions.size());
+        assertEquals("There should be 28 total regions. This will change in future versions of the AWS SDK", 29, regions.size());
     }
 
     @Test


### PR DESCRIPTION
## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

This SDK update fixes an issue when using IRSA in K8s where the AWS Profile is not set. 