### PR TITLE
Minor changes for Jackson 12.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "build": "webpack",
-    "test": "jest",
+    "test": "jest --config=jest.config.js",
     "lint": "eslint src",
     "lint:path": "eslint",
     "lint:styles": "stylelint './src/web/**/*.{js,jsx,ts,tsx}' --syntax css-in-js",

--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,6 @@
                     <artifactSet>
                         <excludes>
                             <exclude>com.google.guava:guava</exclude>
-                            <exclude>com.fasterxml.jackson.core:*</exclude>
                             <exclude>org.apache.httpcomponents:httpclient</exclude>
                             <exclude>joda-time:joda-time</exclude>
                             <exclude>commons-codec:commons-codec</exclude>


### PR DESCRIPTION
We are updating Jackson to a current version, so we no longer need the dependency exclusion.
Also includes an update of the Jest config, required by the [updated Jest client](https://github.com/graylog-labs/Jest/pull/4) for ES6.