### PR TITLE
Properly register notification config entity subtypes

### DIFF
--- a/src/main/java/org/graylog/integrations/IntegrationsModule.java
+++ b/src/main/java/org/graylog/integrations/IntegrationsModule.java
@@ -37,11 +37,13 @@ import org.graylog.integrations.ipfix.inputs.IpfixUdpInput;
 import org.graylog.integrations.ipfix.transports.IpfixUdpTransport;
 import org.graylog.integrations.notifications.types.SlackEventNotification;
 import org.graylog.integrations.notifications.types.SlackEventNotificationConfig;
+import org.graylog.integrations.notifications.types.SlackEventNotificationConfigEntity;
 import org.graylog.integrations.notifications.types.microsoftteams.TeamsEventNotification;
 import org.graylog.integrations.notifications.types.microsoftteams.TeamsEventNotificationConfig;
 import org.graylog.integrations.notifications.types.microsoftteams.TeamsEventNotificationConfigEntity;
 import org.graylog.integrations.pagerduty.PagerDutyNotification;
 import org.graylog.integrations.pagerduty.PagerDutyNotificationConfig;
+import org.graylog.integrations.pagerduty.PagerDutyNotificationConfigEntity;
 import org.graylog2.plugin.PluginConfigBean;
 import org.graylog2.plugin.PluginModule;
 import org.slf4j.Logger;
@@ -105,23 +107,25 @@ public class IntegrationsModule extends PluginModule {
             addNotificationType(SlackEventNotificationConfig.TYPE_NAME,
                     SlackEventNotificationConfig.class,
                     SlackEventNotification.class,
-                    SlackEventNotification.Factory.class);
+                    SlackEventNotification.Factory.class,
+                    SlackEventNotificationConfigEntity.TYPE_NAME,
+                    SlackEventNotificationConfigEntity.class);
 
             // Teams Notification
             addNotificationType(TeamsEventNotificationConfig.TYPE_NAME,
                     TeamsEventNotificationConfig.class,
                     TeamsEventNotification.class,
-                    TeamsEventNotification.Factory.class);
-            // Adds content pack support for Teams Notification.
-            registerJacksonSubtype(TeamsEventNotificationConfigEntity.class,
-                    TeamsEventNotificationConfigEntity.TYPE_NAME);
+                    TeamsEventNotification.Factory.class,
+                    TeamsEventNotificationConfigEntity.TYPE_NAME,
+                    TeamsEventNotificationConfigEntity.class);
 
             // Pager Duty Notification
-            addNotificationType(
-                    PagerDutyNotificationConfig.TYPE_NAME,
+            addNotificationType(PagerDutyNotificationConfig.TYPE_NAME,
                     PagerDutyNotificationConfig.class,
                     PagerDutyNotification.class,
-                    PagerDutyNotification.Factory.class);
+                    PagerDutyNotification.Factory.class,
+                    PagerDutyNotificationConfigEntity.TYPE_NAME,
+                    PagerDutyNotificationConfigEntity.class);
 
             // GreyNoise Data Adapter
             installLookupDataAdapter(GreyNoiseQuickIPDataAdapter.NAME,


### PR DESCRIPTION
Properly registers event notification Jackson subtype for Pager Duty, Slack, and Teams Notifications. Prevents the following exception when attempting to install Event Notification content packs:

```
java.lang.IllegalArgumentException: Could not resolve type id '<notification-type>' as a subtype of...
```

Closes https://github.com/Graylog2/graylog2-server/issues/7801 https://github.com/Graylog2/graylog-plugin-integrations/issues/1113

/jenkins-pr-deps https://github.com/Graylog2/graylog2-server/pull/13171

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging