### PR TITLE
Rework Microsoft Teams Notification Templating

### DIFF
--- a/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotification.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotification.java
@@ -16,7 +16,6 @@
  */
 package org.graylog.integrations.notifications.types.microsoftteams;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.floreysoft.jmte.Engine;
 import com.google.common.annotations.VisibleForTesting;
@@ -38,9 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -114,7 +111,7 @@ public class TeamsEventNotification implements EventNotification {
     TeamsMessage createTeamsMessage(EventNotificationContext ctx, TeamsEventNotificationConfig config) throws PermanentEventNotificationException {
         String messageTitle = buildDefaultMessage(ctx);
         String description = buildMessageDescription(ctx);
-        JsonNode customMessage = null;
+        String customMessage = null;
         String template = config.customMessage();
         if (!isNullOrEmpty(template)) {
             customMessage = buildCustomMessage(ctx, config, template);
@@ -123,7 +120,7 @@ public class TeamsEventNotification implements EventNotification {
         TeamsMessage.Sections section = TeamsMessage.Sections.builder()
                 .activityImage(config.iconUrl())
                 .activitySubtitle(description)
-                .facts(customMessage)
+                .text(customMessage)
                 .build();
 
         return TeamsMessage.builder()
@@ -146,38 +143,16 @@ public class TeamsEventNotification implements EventNotification {
     }
 
 
-    JsonNode buildCustomMessage(EventNotificationContext ctx, TeamsEventNotificationConfig config, String template) throws PermanentEventNotificationException {
+    String buildCustomMessage(EventNotificationContext ctx, TeamsEventNotificationConfig config, String template) throws PermanentEventNotificationException {
         final List<MessageSummary> backlog = getMessageBacklog(ctx, config);
         Map<String, Object> model = getCustomMessageModel(ctx, config.type(), backlog);
         try {
-            String facts = templateEngine.transform(template, model);
-            JsonNode factsNode = getMessageDetails(facts);
-            LOG.debug("customMessage: template = {} model = {}", template, model);
-            return factsNode;
+            return templateEngine.transform(template, model);
         } catch (Exception e) {
             String error = "Invalid Custom Message template.";
             LOG.error("{} [{}]", error, e.toString());
             throw new PermanentEventNotificationException(error + e, e.getCause());
         }
-    }
-
-    public JsonNode getMessageDetails(String eventFields) {
-        String[] fields = eventFields.split("\\r?\\n");
-        List<Map<String, String>> event = new ArrayList<>();
-        for (String field : fields) {
-            Map<String, String> facts = new HashMap<>();
-            int firstColonIdx = field.indexOf(':');
-            if (firstColonIdx == -1) {
-                facts.put("name", field);
-            } else {
-                facts.put("name", field.substring(0, firstColonIdx));
-                facts.put("value", field.substring(firstColonIdx + 1).trim());
-            }
-            event.add(facts);
-        }
-        LOG.debug("Created list of facts");
-        return objectMapper.convertValue(event, JsonNode.class);
-
     }
 
     @VisibleForTesting

--- a/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotification.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotification.java
@@ -166,9 +166,13 @@ public class TeamsEventNotification implements EventNotification {
         List<Map<String, String>> event = new ArrayList<>();
         for (String field : fields) {
             Map<String, String> facts = new HashMap<>();
-            String[] factFields = field.split(":");
-            facts.put("name", factFields[0]);
-            facts.put("value", factFields.length == 1 ? "" : factFields[1].trim());
+            int firstColonIdx = field.indexOf(':');
+            if (firstColonIdx == -1) {
+                facts.put("name", field);
+            } else {
+                facts.put("name", field.substring(0, firstColonIdx));
+                facts.put("value", field.substring(firstColonIdx + 1).trim());
+            }
             event.add(facts);
         }
         LOG.debug("Created list of facts");

--- a/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsMessage.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsMessage.java
@@ -18,7 +18,6 @@ package org.graylog.integrations.notifications.types.microsoftteams;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 
@@ -39,7 +38,6 @@ public abstract class TeamsMessage {
     static final String FIELD_SECTIONS = "sections";
     static final String FIELD_ACTIVITY_SUBTITLE = "activitySubtitle";
     static final String FIELD_ACTIVITY_IMAGE = "activityImage";
-    static final String FIELD_FACTS = "facts";
 
     @JsonProperty(FIELD_TYPE)
     public abstract String type();
@@ -101,8 +99,8 @@ public abstract class TeamsMessage {
         @JsonProperty(FIELD_ACTIVITY_IMAGE)
         public abstract String activityImage();
 
-        @JsonProperty(FIELD_FACTS)
-        public abstract JsonNode facts();
+        @JsonProperty(FIELD_TEXT)
+        public abstract String text();
 
         public abstract Builder toBuilder();
 
@@ -119,8 +117,8 @@ public abstract class TeamsMessage {
             @JsonProperty(FIELD_ACTIVITY_IMAGE)
             public abstract Builder activityImage(String activityImage);
 
-            @JsonProperty(FIELD_FACTS)
-            public abstract Builder facts(JsonNode facts);
+            @JsonProperty(FIELD_TEXT)
+            public abstract Builder text(String text);
 
             public abstract Sections build();
         }

--- a/src/test/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationTest.java
@@ -42,6 +42,7 @@ import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -110,6 +111,17 @@ public class TeamsEventNotificationTest {
                 .build();
     }
 
+    private TeamsEventNotificationConfig getTemplatedTimestampConfig() {
+        return TeamsEventNotificationConfig.builder()
+                .type(TeamsEventNotificationConfig.TYPE_NAME)
+                .color(expectedColor)
+                .webhookUrl("axzzzz")
+                .backlogSize(1)
+                .iconUrl(expectedImage)
+                .customMessage("Timestamp: ${event.timestamp}")
+                .build();
+    }
+
     private NotificationDto getHttpNotification() {
         return NotificationDto.builder()
                 .title("Foobar")
@@ -135,6 +147,17 @@ public class TeamsEventNotificationTest {
         assertThat(section.activitySubtitle()).isEqualTo(expectedSubtitle);
         assertThat(section.activityImage()).isEqualTo(expectedImage);
         assertThat(section.facts().toString().contains("\"name\":\"a custom message\"")).isTrue();
+    }
+
+    @Test
+    public void testValidTimestampFields() throws EventNotificationException {
+        TeamsMessage actual = teamsEventNotification.createTeamsMessage(eventNotificationContext, getTemplatedTimestampConfig());
+        JsonNode node = actual.sections().iterator().next().facts().iterator().next();
+        assertThat(node.has("value")).isTrue();
+        String timestampString = node.get("value").asText();
+        assertThat(timestampString).contains(":");
+        DateTime dt = DateTime.parse(timestampString, DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"));
+        assertThat(dt).isNotNull();
     }
 
     @After
@@ -206,7 +229,7 @@ public class TeamsEventNotificationTest {
                 .fields(ImmutableMap.of("hello", "world"))
                 .build();
 
-        //uses the eventDEfinitionDto from NotificationTestData.getDummyContext in the setup method
+        //uses the eventDefinitionDto from NotificationTestData.getDummyContext in the setup method
         EventDefinitionDto eventDefinitionDto = eventNotificationContext.eventDefinition().orElseThrow(NullPointerException::new);
         return EventNotificationContext.builder()
                 .notificationId("1234")

--- a/src/web/event-notifications/event-notification-types/TeamsNotificationForm.tsx
+++ b/src/web/event-notifications/event-notification-types/TeamsNotificationForm.tsx
@@ -27,9 +27,9 @@ import ColorLabel from 'components/sidecars/common/ColorLabel';
 import type { ConfigType, ValidationType } from '../types';
 
 type TeamsNotificationFormType = {
-      config: ConfigType,
-      validation: ValidationType
-      onChange: any
+  config: ConfigType,
+  validation: ValidationType
+  onChange: any
 }
 
 class TeamsNotificationForm extends React.Component<TeamsNotificationFormType, any> {
@@ -38,31 +38,37 @@ class TeamsNotificationForm extends React.Component<TeamsNotificationFormType, a
     webhook_url: '',
     /* eslint-disable no-template-curly-in-string */
     custom_message: ''
-                      + '--- [Event Definition] ----\n'
-                      + 'Title:       ${event_definition_title}\n'
-                      + 'Type:        ${event_definition_type}\n'
-                      + '--- [Event] ----\n'
-                      + 'Timestamp:            ${event.timestamp}\n'
-                      + 'Message:              ${event.message}\n'
-                      + 'Source:               ${event.source}\n'
-                      + 'Key:                  ${event.key}\n'
-                      + 'Priority:             ${event.priority}\n'
-                      + 'Alert:                ${event.alert}\n'
-                      + 'Timestamp Processing: ${event.timestamp}\n'
-                      + 'Timerange Start:      ${event.timerange_start}\n'
-                      + 'Timerange End:        ${event.timerange_end}\n'
-                      + 'Event Fields:\n'
-                      + '${foreach event.fields field}\n'
-                      + '${field.key}: ${field.value}\n'
-                      + '${end}\n'
-                      + '${if backlog}\n'
-                      + '--- [Backlog] ----------\n'
-                      + 'Last messages accounting for this alert:\n'
-                      + '${foreach backlog message}\n'
-                      + '${message.timestamp}  ::  ${message.source}  ::  ${message.message}\n'
-                      + '${message.message}\n'
-                      + '${end}'
-                      + '${end}\n',
+      + '<b>--- [Event Definition] ---</b>\n'
+      + '<table>\n'
+      + '<tr><td><b>Title:</b></td><td>${event_definition_title}</td></tr>\n'
+      + '<tr><td><b>Type:</b></td><td>${event_definition_type}</td></tr>\n'
+      + '<table>\n'
+      + '\n'
+      + '<b>--- [Event] ---</b>\n'
+      + '<table>\n'
+      + '<tr><td><b>Timestamp:</b></td><td>${event.timestamp}</td></tr>\n'
+      + '<tr><td><b>Message:</b></td><td>${event.message}</td></tr>\n'
+      + '<tr><td><b>Source:</b></td><td>${event.source}</td></tr>\n'
+      + '<tr><td><b>Key:</b></td><td>${event.key}</td></tr>\n'
+      + '<tr><td><b>Priority:</b></td><td>${event.priority}</td></tr>\n'
+      + '<tr><td><b>Alert:</b></td><td>${event.alert}</td></tr>\n'
+      + '<tr><td><b>Timestamp Processing:</b></td><td>${event.timestamp}</td></tr>\n'
+      + '<tr><td><b>Timerange Start:</b></td><td>${event.timerange_start}</td></tr>\n'
+      + '<tr><td><b>Timerange End:</b></td><td>${event.timerange_end}</td></tr>\n'
+      + '<table>\n'
+      + '\n'
+      + '<b>Event Fields:</b>\n'
+      + '<table>\n'
+      + '${foreach event.fields field}\n'
+      + '<tr><td><b>${field.key}:</b></td><td>${field.value}</td></tr>\n'
+      + '${end}\n'
+      + '</table>\n'
+      + '\n'
+      + '${if backlog}\n'
+      + '<b>--- [Backlog] ---</b>\n'
+      + '${foreach backlog message}\n'
+      + '<p><code>${message.timestamp}  ::  ${message.source}  ::  ${message.message}</code></p>\n'
+      + '${end}${end}',
     /* eslint-enable no-template-curly-in-string */
     icon_url: '',
     backlog_size: 0,


### PR DESCRIPTION
Previously, the actual format of the MS Teams Notification template didn't matter all that much. The code was parsing each line into a key value pair with a colon char delimiter so the `sections.facts` part of the [O365 connector card](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference#properties-of-the-office-365-connector-card), which relies on key-value pairings, could be used. If the value itself contained a colon then it would be cut off from that colon on. This broke timestamp fields and just didn't work all that well for things like backlog messages, which doesn't fit into a key-value pattern. 

These changes instead use the `text` field of the O365 connector card which allows for the template of the notification to include HTML or markdown more easily.

**This does introduce a breaking change for existing MSTeams Notifications using the old, default notification template**
![image](https://user-images.githubusercontent.com/91903901/196285917-7e3bf291-52de-4086-831c-75c47a886ad7.png)
Users will need to either fixup their markup beforehand so that it is actually used, or can update their notifications with the new default notification template that includes HTML. See Graylog2/graylog2-server#13738 for UPGRADING.md additions.

```
<table>
<tr><td><b>--- [Event Definition] ---</b></td></tr>
<tr><td><b>Title:</b></td><td>${event_definition_title}</td></tr>
<tr><td><b>Type:</b></td><td>${event_definition_type}</td></tr>

<tr><td><b>--- [Event] ---</b></td></tr>
<tr><td><b>Timestamp:</b></td><td>${event.timestamp}</td></tr>
<tr><td><b>Message:</b></td><td>${event.message}</td></tr>
<tr><td><b>Source:</b></td><td>${event.source}</td></tr>
<tr><td><b>Key:</b></td><td>${event.key}</td></tr>
<tr><td><b>Priority:</b></td><td>${event.priority}</td></tr>
<tr><td><b>Alert:</b></td><td>${event.alert}</td></tr>
<tr><td><b>Timestamp Processing:</b></td><td>${event.timestamp}</td></tr>
<tr><td><b>Timerange Start:</b></td><td>${event.timerange_start}</td></tr>
<tr><td><b>Timerange End:</b></td><td>${event.timerange_end}</td></tr>
<table>

<b>Event Fields:</b>
<table>
${foreach event.fields field}
<tr><td><b>${field.key}:</b></td><td>${field.value}</td></tr>
${end}
</table>

${if backlog}
<b>--- [Backlog] ---</b>
${foreach backlog message}
<pre>${message.timestamp}  ::  ${message.source}  ::  ${message.message}</pre>
${end}${end}
```

This new format should look almost identical to the previous one, except that fields with colons will actually render properly and so will the backlog. The `<pre>` tag may need to be tweaked if messages contained unescaped HTML characters.. but just removing them will work too. I'm also open to reworking that template and happily taking suggestions for improvements. Here is an example of a notification using the new code and template.

![image](https://user-images.githubusercontent.com/91903901/196288024-46b9498d-cf7f-4726-a030-e3aabc69f52a.png)


Also note the timestamps are now formatted differently, but I plan on cleaning that up in a separate PR addressing Graylog2/graylog2-server#13421

closes #1200
closes #1096

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

