### PR TITLE
Update PaloAlto9xTemplates.java

### DIFF
--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
@@ -263,7 +263,7 @@ public class PaloAlto9xTemplates {
 
         fields.add(create(PaloAlto9xFields.PAN_LOG_PANORAMA, 35, STRING));
         fields.add(create(PaloAlto9xFields.PAN_SELECTION_TYPE, 36, STRING));
-        fields.add(create(ApplicationFields.APPLICATION_RESPONSE_TIME, 37, LONG));
+        fields.add(create(ApplicationFields.APPLICATION_RESPONSE_TIME, 37, STRING));
         fields.add(create(PaloAlto9xFields.PAN_GATEWAY_PRIORITY, 38, LONG));
         fields.add(create(PaloAlto9xFields.PAN_ATTEMPTED_GATEWAYS, 39, STRING));
 


### PR DESCRIPTION
Addressed 
ERROR [PaloAltoTypeParser] Error parsing field application_response_time, auto is not a valid numeric value

## Notes for Reviewers

- [x] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [x] Sync up with the author before merging

