### PR TITLE
feat: consistent identifier for inputs

### DIFF
--- a/changelog/unreleased/pr-1291.toml
+++ b/changelog/unreleased/pr-1291.toml
@@ -1,0 +1,5 @@
+type = "changed" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "Consistent use of message identifiers in strings."
+
+issues = ["Graylog2/graylog2-server#13628"]
+pulls = ["1291"]

--- a/src/main/java/org/graylog/integrations/aws/transports/KinesisTransport.java
+++ b/src/main/java/org/graylog/integrations/aws/transports/KinesisTransport.java
@@ -140,7 +140,7 @@ public class KinesisTransport extends ThrottleableTransport {
         this.kinesisConsumer = new KinesisConsumer(nodeId, this, objectMapper, kinesisCallback(input),
                                                    streamName, awsMessageType, batchSize, awsRequest);
 
-        LOG.debug("Starting Kinesis reader thread for input [{}/{}]", input.getName(), input.getId());
+        LOG.debug("Starting Kinesis reader thread for input {}", input.toIdentifier());
         executor.submit(this.kinesisConsumer);
     }
 


### PR DESCRIPTION
Replaces all representations in strings for inputs to a new toIdentifier() method which concatenates {name}/{title}/{id}
/jenkins-pr-deps Graylog2/graylog2-server#14562

to be merged after / dependent on https://github.com/Graylog2/graylog2-server/pull/14562

