### PR TITLE
Remove extra declaration of AWS SDK version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,6 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.site.skip>true</maven.site.skip>
         <graylog.version>5.1.0-SNAPSHOT</graylog.version>
-        <aws-java-sdk-2.version>2.17.77</aws-java-sdk-2.version>
         <aws-kinesis-client.version>2.2.10</aws-kinesis-client.version>
         <integrations.protobuf.version>3.11.1</integrations.protobuf.version>
     </properties>


### PR DESCRIPTION
The extra declaration in this plugin is not needed. The server declaration of the property is now used. 

/jenkins-pr-deps https://github.com/Graylog2/graylog2-server/pull/14712
/nocl
## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

