### PR TITLE
Slack and MS Teams Notification Improvements

### DIFF
--- a/changelog/unreleased/issue-1172.toml
+++ b/changelog/unreleased/issue-1172.toml
@@ -1,0 +1,5 @@
+type = "added"
+message = "Added option to omit title portion of Slack notifications to reduce clutter."
+
+issues = ["1172"]
+pulls = ["1320"]

--- a/changelog/unreleased/issue-1318.toml
+++ b/changelog/unreleased/issue-1318.toml
@@ -1,0 +1,5 @@
+type = "added"
+message = "Added support for timezones in Slack and Teams notifications."
+
+issues = ["1318"]
+pulls = ["1320"]

--- a/changelog/unreleased/issue-780.toml
+++ b/changelog/unreleased/issue-780.toml
@@ -1,0 +1,5 @@
+type = "added"
+message = "Added option to notify @here in Slack notifications."
+
+issues = ["780"]
+pulls = ["1320"]

--- a/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfig.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfig.java
@@ -57,6 +57,7 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
     static final String INVALID_SLACK_URL_ERROR_MESSAGE = "Specified Webhook URL is not a valid Slack URL";
     static final String INVALID_DISCORD_URL_ERROR_MESSAGE = "Specified Webhook URL is not a valid Discord URL";
     static final String EMPTY_BODY_ERROR_MESSAGE = "If custom message is empty the title must be included";
+    static final String INVALID_NOTIFY_SETTINGS = "Can only notify either @channel or @here, not both.";
     static final String WEB_HOOK_URL = "https://hooks.slack.com/services/xxx/xxxx/xxxxxxxxxxxxxxxxxxx";
     static final String CHANNEL = "#general";
 
@@ -66,6 +67,7 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
     static final String FIELD_CUSTOM_MESSAGE = "custom_message";
     static final String FIELD_USER_NAME = "user_name";
     static final String FIELD_NOTIFY_CHANNEL = "notify_channel";
+    static final String FIELD_NOTIFY_HERE = "notify_here";
     static final String FIELD_LINK_NAMES = "link_names";
     static final String FIELD_ICON_URL = "icon_url";
     static final String FIELD_ICON_EMOJI = "icon_emoji";
@@ -115,6 +117,9 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
     @JsonProperty(FIELD_INCLUDE_TITLE)
     public abstract Boolean includeTitle();
 
+    @JsonProperty(FIELD_NOTIFY_HERE)
+    public abstract Boolean notifyHere();
+
     @Override
     @JsonIgnore
     public JobTriggerData toJobTriggerData(EventDto dto) {
@@ -159,6 +164,11 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
             validation.addError(FIELD_INCLUDE_TITLE, EMPTY_BODY_ERROR_MESSAGE);
         }
 
+        if (notifyChannel() && notifyHere()) {
+            validation.addError(FIELD_NOTIFY_CHANNEL, INVALID_NOTIFY_SETTINGS);
+            validation.addError(FIELD_NOTIFY_HERE, INVALID_NOTIFY_SETTINGS);
+        }
+
         return validation;
     }
 
@@ -174,6 +184,7 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
                     .channel(CHANNEL)
                     .customMessage(DEFAULT_CUSTOM_MESSAGE)
                     .notifyChannel(false)
+                    .notifyHere(false)
                     .backlogSize(DEFAULT_BACKLOG_SIZE)
                     .linkNames(false)
                     .timeZone(DEFAULT_TIME_ZONE)
@@ -216,6 +227,9 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
         @JsonProperty(FIELD_INCLUDE_TITLE)
         public abstract Builder includeTitle(Boolean includeTitle);
 
+        @JsonProperty(FIELD_NOTIFY_HERE)
+        public abstract Builder notifyHere(Boolean notifyHere);
+
         public abstract SlackEventNotificationConfig build();
     }
 
@@ -232,6 +246,7 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
                 .iconUrl(ValueReference.of(iconUrl()))
                 .iconEmoji(ValueReference.of(iconEmoji()))
                 .timeZone(ValueReference.of(timeZone().getID()))
+                .notifyHere(ValueReference.of(notifyHere()))
                 .build();
     }
 }

--- a/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfig.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfig.java
@@ -30,6 +30,7 @@ import org.graylog.scheduler.JobTriggerData;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.plugin.rest.ValidationResult;
+import org.joda.time.DateTimeZone;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
@@ -48,6 +49,7 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
     private static final String DEFAULT_HEX_COLOR = "#ff0500";
     private static final String DEFAULT_CUSTOM_MESSAGE = "Graylog Slack Notification";
     private static final long DEFAULT_BACKLOG_SIZE = 0;
+    private static final DateTimeZone DEFAULT_TIME_ZONE = DateTimeZone.UTC;
 
     static final String INVALID_BACKLOG_ERROR_MESSAGE = "Backlog size cannot be less than zero";
     static final String INVALID_CHANNEL_ERROR_MESSAGE = "Channel cannot be empty";
@@ -67,6 +69,7 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
     static final String FIELD_ICON_URL = "icon_url";
     static final String FIELD_ICON_EMOJI = "icon_emoji";
     static final String FIELD_BACKLOG_SIZE = "backlog_size";
+    static final String FIELD_TIME_ZONE = "time_zone";
 
     @JsonProperty(FIELD_BACKLOG_SIZE)
     public abstract long backlogSize();
@@ -103,6 +106,9 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
     @JsonProperty(FIELD_ICON_EMOJI)
     @Nullable
     public abstract String iconEmoji();
+
+    @JsonProperty(FIELD_TIME_ZONE)
+    public abstract DateTimeZone timeZone();
 
     @Override
     @JsonIgnore
@@ -159,7 +165,8 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
                     .customMessage(DEFAULT_CUSTOM_MESSAGE)
                     .notifyChannel(false)
                     .backlogSize(DEFAULT_BACKLOG_SIZE)
-                    .linkNames(false);
+                    .linkNames(false)
+                    .timeZone(DEFAULT_TIME_ZONE);
         }
 
         @JsonProperty(FIELD_COLOR)
@@ -192,6 +199,9 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
         @JsonProperty(FIELD_BACKLOG_SIZE)
         public abstract SlackEventNotificationConfig.Builder backlogSize(long backlogSize);
 
+        @JsonProperty(FIELD_TIME_ZONE)
+        public abstract SlackEventNotificationConfig.Builder timeZone(DateTimeZone timeZone);
+
         public abstract SlackEventNotificationConfig build();
     }
 
@@ -207,6 +217,7 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
                 .linkNames(ValueReference.of(linkNames()))
                 .iconUrl(ValueReference.of(iconUrl()))
                 .iconEmoji(ValueReference.of(iconEmoji()))
+                .timeZone(ValueReference.of(timeZone().getID()))
                 .build();
     }
 }

--- a/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfig.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfig.java
@@ -56,6 +56,7 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
     static final String INVALID_WEBHOOK_ERROR_MESSAGE = "Specified Webhook URL is not a valid URL";
     static final String INVALID_SLACK_URL_ERROR_MESSAGE = "Specified Webhook URL is not a valid Slack URL";
     static final String INVALID_DISCORD_URL_ERROR_MESSAGE = "Specified Webhook URL is not a valid Discord URL";
+    static final String EMPTY_BODY_ERROR_MESSAGE = "If custom message is empty the title must be included";
     static final String WEB_HOOK_URL = "https://hooks.slack.com/services/xxx/xxxx/xxxxxxxxxxxxxxxxxxx";
     static final String CHANNEL = "#general";
 
@@ -70,6 +71,7 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
     static final String FIELD_ICON_EMOJI = "icon_emoji";
     static final String FIELD_BACKLOG_SIZE = "backlog_size";
     static final String FIELD_TIME_ZONE = "time_zone";
+    static final String FIELD_INCLUDE_TITLE = "include_title";
 
     @JsonProperty(FIELD_BACKLOG_SIZE)
     public abstract long backlogSize();
@@ -110,6 +112,9 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
     @JsonProperty(FIELD_TIME_ZONE)
     public abstract DateTimeZone timeZone();
 
+    @JsonProperty(FIELD_INCLUDE_TITLE)
+    public abstract Boolean includeTitle();
+
     @Override
     @JsonIgnore
     public JobTriggerData toJobTriggerData(EventDto dto) {
@@ -149,13 +154,18 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
             validation.addError(FIELD_CHANNEL, INVALID_CHANNEL_ERROR_MESSAGE);
         }
 
+        if (!includeTitle() && (customMessage() == null || customMessage().isBlank())) {
+            validation.addError(FIELD_CUSTOM_MESSAGE, EMPTY_BODY_ERROR_MESSAGE);
+            validation.addError(FIELD_INCLUDE_TITLE, EMPTY_BODY_ERROR_MESSAGE);
+        }
+
         return validation;
     }
 
     @AutoValue.Builder
     public static abstract class Builder implements EventNotificationConfig.Builder<SlackEventNotificationConfig.Builder> {
         @JsonCreator
-        public static SlackEventNotificationConfig.Builder create() {
+        public static Builder create() {
 
             return new AutoValue_SlackEventNotificationConfig.Builder()
                     .type(TYPE_NAME)
@@ -166,41 +176,45 @@ public abstract class SlackEventNotificationConfig implements EventNotificationC
                     .notifyChannel(false)
                     .backlogSize(DEFAULT_BACKLOG_SIZE)
                     .linkNames(false)
-                    .timeZone(DEFAULT_TIME_ZONE);
+                    .timeZone(DEFAULT_TIME_ZONE)
+                    .includeTitle(true);
         }
 
         @JsonProperty(FIELD_COLOR)
-        public abstract SlackEventNotificationConfig.Builder color(String color);
+        public abstract Builder color(String color);
 
         @JsonProperty(FIELD_WEBHOOK_URL)
-        public abstract SlackEventNotificationConfig.Builder webhookUrl(String webhookUrl);
+        public abstract Builder webhookUrl(String webhookUrl);
 
         @JsonProperty(FIELD_CHANNEL)
-        public abstract SlackEventNotificationConfig.Builder channel(String channel);
+        public abstract Builder channel(String channel);
 
         @JsonProperty(FIELD_CUSTOM_MESSAGE)
-        public abstract SlackEventNotificationConfig.Builder customMessage(String customMessage);
+        public abstract Builder customMessage(String customMessage);
 
         @JsonProperty(FIELD_USER_NAME)
-        public abstract SlackEventNotificationConfig.Builder userName(String userName);
+        public abstract Builder userName(String userName);
 
         @JsonProperty(FIELD_NOTIFY_CHANNEL)
-        public abstract SlackEventNotificationConfig.Builder notifyChannel(boolean notifyChannel);
+        public abstract Builder notifyChannel(boolean notifyChannel);
 
         @JsonProperty(FIELD_LINK_NAMES)
-        public abstract SlackEventNotificationConfig.Builder linkNames(boolean linkNames);
+        public abstract Builder linkNames(boolean linkNames);
 
         @JsonProperty(FIELD_ICON_URL)
-        public abstract SlackEventNotificationConfig.Builder iconUrl(String iconUrl);
+        public abstract Builder iconUrl(String iconUrl);
 
         @JsonProperty(FIELD_ICON_EMOJI)
-        public abstract SlackEventNotificationConfig.Builder iconEmoji(String iconEmoji);
+        public abstract Builder iconEmoji(String iconEmoji);
 
         @JsonProperty(FIELD_BACKLOG_SIZE)
-        public abstract SlackEventNotificationConfig.Builder backlogSize(long backlogSize);
+        public abstract Builder backlogSize(long backlogSize);
 
         @JsonProperty(FIELD_TIME_ZONE)
-        public abstract SlackEventNotificationConfig.Builder timeZone(DateTimeZone timeZone);
+        public abstract Builder timeZone(DateTimeZone timeZone);
+
+        @JsonProperty(FIELD_INCLUDE_TITLE)
+        public abstract Builder includeTitle(Boolean includeTitle);
 
         public abstract SlackEventNotificationConfig build();
     }

--- a/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigEntity.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigEntity.java
@@ -25,6 +25,7 @@ import org.graylog.events.contentpack.entities.EventNotificationConfigEntity;
 import org.graylog.events.notifications.EventNotificationConfig;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
+import org.joda.time.DateTimeZone;
 
 import java.util.Map;
 
@@ -62,6 +63,9 @@ public abstract class SlackEventNotificationConfigEntity implements EventNotific
     @JsonProperty(SlackEventNotificationConfig.FIELD_ICON_EMOJI)
     public abstract ValueReference iconEmoji();
 
+    @JsonProperty(SlackEventNotificationConfig.FIELD_TIME_ZONE)
+    public abstract ValueReference timeZone();
+
     public static Builder builder() {
         return Builder.create();
     }
@@ -74,7 +78,8 @@ public abstract class SlackEventNotificationConfigEntity implements EventNotific
         @JsonCreator
         public static Builder create() {
             return new AutoValue_SlackEventNotificationConfigEntity.Builder()
-                    .type(TYPE_NAME);
+                    .type(TYPE_NAME)
+                    .timeZone(ValueReference.of("UTC"));
         }
 
         @JsonProperty(SlackEventNotificationConfig.FIELD_COLOR)
@@ -104,6 +109,9 @@ public abstract class SlackEventNotificationConfigEntity implements EventNotific
         @JsonProperty(SlackEventNotificationConfig.FIELD_ICON_EMOJI)
         public abstract Builder iconEmoji(ValueReference iconEmoji);
 
+        @JsonProperty(SlackEventNotificationConfig.FIELD_TIME_ZONE)
+        public abstract Builder timeZone(ValueReference timeZone);
+
         public abstract SlackEventNotificationConfigEntity build();
     }
 
@@ -119,6 +127,7 @@ public abstract class SlackEventNotificationConfigEntity implements EventNotific
                 .linkNames(linkNames().asBoolean(parameters))
                 .iconUrl(iconUrl().asString(parameters))
                 .iconEmoji(iconEmoji().asString(parameters))
+                .timeZone(DateTimeZone.forID(timeZone().asString(parameters)))
                 .build();
     }
 }

--- a/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigEntity.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigEntity.java
@@ -66,6 +66,9 @@ public abstract class SlackEventNotificationConfigEntity implements EventNotific
     @JsonProperty(SlackEventNotificationConfig.FIELD_TIME_ZONE)
     public abstract ValueReference timeZone();
 
+    @JsonProperty(SlackEventNotificationConfig.FIELD_INCLUDE_TITLE)
+    public abstract ValueReference includeTitle();
+
     public static Builder builder() {
         return Builder.create();
     }
@@ -79,7 +82,8 @@ public abstract class SlackEventNotificationConfigEntity implements EventNotific
         public static Builder create() {
             return new AutoValue_SlackEventNotificationConfigEntity.Builder()
                     .type(TYPE_NAME)
-                    .timeZone(ValueReference.of("UTC"));
+                    .timeZone(ValueReference.of("UTC"))
+                    .includeTitle(ValueReference.of(true));
         }
 
         @JsonProperty(SlackEventNotificationConfig.FIELD_COLOR)
@@ -112,6 +116,9 @@ public abstract class SlackEventNotificationConfigEntity implements EventNotific
         @JsonProperty(SlackEventNotificationConfig.FIELD_TIME_ZONE)
         public abstract Builder timeZone(ValueReference timeZone);
 
+        @JsonProperty(SlackEventNotificationConfig.FIELD_INCLUDE_TITLE)
+        public abstract Builder includeTitle(ValueReference includeTitle);
+
         public abstract SlackEventNotificationConfigEntity build();
     }
 
@@ -128,6 +135,7 @@ public abstract class SlackEventNotificationConfigEntity implements EventNotific
                 .iconUrl(iconUrl().asString(parameters))
                 .iconEmoji(iconEmoji().asString(parameters))
                 .timeZone(DateTimeZone.forID(timeZone().asString(parameters)))
+                .includeTitle(includeTitle().asBoolean(parameters))
                 .build();
     }
 }

--- a/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigEntity.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/SlackEventNotificationConfigEntity.java
@@ -69,6 +69,9 @@ public abstract class SlackEventNotificationConfigEntity implements EventNotific
     @JsonProperty(SlackEventNotificationConfig.FIELD_INCLUDE_TITLE)
     public abstract ValueReference includeTitle();
 
+    @JsonProperty(SlackEventNotificationConfig.FIELD_NOTIFY_HERE)
+    public abstract ValueReference notifyHere();
+
     public static Builder builder() {
         return Builder.create();
     }
@@ -83,7 +86,8 @@ public abstract class SlackEventNotificationConfigEntity implements EventNotific
             return new AutoValue_SlackEventNotificationConfigEntity.Builder()
                     .type(TYPE_NAME)
                     .timeZone(ValueReference.of("UTC"))
-                    .includeTitle(ValueReference.of(true));
+                    .includeTitle(ValueReference.of(true))
+                    .notifyHere(ValueReference.of(false));
         }
 
         @JsonProperty(SlackEventNotificationConfig.FIELD_COLOR)
@@ -119,6 +123,9 @@ public abstract class SlackEventNotificationConfigEntity implements EventNotific
         @JsonProperty(SlackEventNotificationConfig.FIELD_INCLUDE_TITLE)
         public abstract Builder includeTitle(ValueReference includeTitle);
 
+        @JsonProperty(SlackEventNotificationConfig.FIELD_NOTIFY_HERE)
+        public abstract Builder notifyHere(ValueReference notifyHere);
+
         public abstract SlackEventNotificationConfigEntity build();
     }
 
@@ -136,6 +143,7 @@ public abstract class SlackEventNotificationConfigEntity implements EventNotific
                 .iconEmoji(iconEmoji().asString(parameters))
                 .timeZone(DateTimeZone.forID(timeZone().asString(parameters)))
                 .includeTitle(includeTitle().asBoolean(parameters))
+                .notifyHere(notifyHere().asBoolean(parameters))
                 .build();
     }
 }

--- a/src/main/java/org/graylog/integrations/notifications/types/SlackMessage.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/SlackMessage.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 
 @AutoValue
@@ -36,10 +37,6 @@ public abstract class SlackMessage {
     private static final String FIELD_ATTACHMENTS = "attachments";
     private static final String FIELD_COLOR = "color";
     private static final String FIELD_ATTACHMENT_TEXT = "text";
-    private static final String FIELD_FALLBACK = "fallback";
-    private static final String FIELD_PRETEXT = "pretext";
-    static final String VALUE_FALLBACK = "Custom Message";
-    static final String VALUE_PRETEXT = "Custom Message:";
 
     @JsonProperty(FIELD_ICON_EMOJI)
     public abstract String iconEmoji();
@@ -56,6 +53,7 @@ public abstract class SlackMessage {
     @JsonProperty(FIELD_LINK_NAMES)
     public abstract boolean linkNames();
 
+    @Nullable
     @JsonProperty(FIELD_TEXT)
     public abstract String text();
 
@@ -100,14 +98,9 @@ public abstract class SlackMessage {
     @AutoValue
     @JsonDeserialize(builder = AutoValue_SlackMessage_Attachment.Builder.class)
     public static abstract class Attachment {
-        @JsonProperty(FIELD_FALLBACK)
-        public abstract String fallback();
-
+        @Nullable
         @JsonProperty(FIELD_ATTACHMENT_TEXT)
         public abstract String text();
-
-        @JsonProperty(FIELD_PRETEXT)
-        public abstract String pretext();
 
         @JsonProperty(FIELD_COLOR)
         public abstract String color();
@@ -120,14 +113,8 @@ public abstract class SlackMessage {
 
         @AutoValue.Builder
         public static abstract class Builder {
-            @JsonProperty(FIELD_FALLBACK)
-            public abstract Builder fallback(String fallback);
-
             @JsonProperty(FIELD_ATTACHMENT_TEXT)
             public abstract Builder text(String fallback);
-
-            @JsonProperty(FIELD_PRETEXT)
-            public abstract Builder pretext(String pretext);
 
             @JsonProperty(FIELD_COLOR)
             public abstract Builder color(String color);
@@ -136,10 +123,8 @@ public abstract class SlackMessage {
 
             @JsonCreator
             public static Builder create() {
-                // Set the pretext and fallback values
-                return new AutoValue_SlackMessage_Attachment.Builder()
-                        .pretext(VALUE_PRETEXT)
-                        .fallback(VALUE_FALLBACK);
+                // Set the fallback values
+                return new AutoValue_SlackMessage_Attachment.Builder();
             }
         }
     }

--- a/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationConfig.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationConfig.java
@@ -30,6 +30,7 @@ import org.graylog.scheduler.JobTriggerData;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.plugin.rest.ValidationResult;
+import org.joda.time.DateTimeZone;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
@@ -47,6 +48,7 @@ public abstract class TeamsEventNotificationConfig implements EventNotificationC
     private static final String DEFAULT_HEX_COLOR = "#ff0500";
     private static final String DEFAULT_CUSTOM_MESSAGE = "Graylog Teams Notification";
     private static final long DEFAULT_BACKLOG_SIZE = 0;
+    private static final DateTimeZone DEFAULT_TIME_ZONE = DateTimeZone.UTC;
 
     static final String INVALID_BACKLOG_ERROR_MESSAGE = "Backlog size cannot be less than zero";
     static final String INVALID_WEBHOOK_ERROR_MESSAGE = "Specified Webhook URL is not a valid URL";
@@ -57,6 +59,7 @@ public abstract class TeamsEventNotificationConfig implements EventNotificationC
     static final String TEAMS_ICON_URL = "icon_url";
     static final String TEAMS_BACKLOG_SIZE = "backlog_size";
     static final String TEAMS_COLOR = "color";
+    static final String TEAMS_TIME_ZONE = "time_zone";
 
     @JsonProperty(TEAMS_BACKLOG_SIZE)
     public abstract long backlogSize();
@@ -75,6 +78,9 @@ public abstract class TeamsEventNotificationConfig implements EventNotificationC
     @JsonProperty(TEAMS_ICON_URL)
     @Nullable
     public abstract String iconUrl();
+
+    @JsonProperty(TEAMS_TIME_ZONE)
+    public abstract DateTimeZone timeZone();
 
     @Override
     @JsonIgnore
@@ -121,7 +127,8 @@ public abstract class TeamsEventNotificationConfig implements EventNotificationC
                     .color(DEFAULT_HEX_COLOR)
                     .webhookUrl(WEB_HOOK_URL)
                     .customMessage(DEFAULT_CUSTOM_MESSAGE)
-                    .backlogSize(DEFAULT_BACKLOG_SIZE);
+                    .backlogSize(DEFAULT_BACKLOG_SIZE)
+                    .timeZone(DEFAULT_TIME_ZONE);
         }
 
         @JsonProperty(TEAMS_COLOR)
@@ -139,6 +146,9 @@ public abstract class TeamsEventNotificationConfig implements EventNotificationC
         @JsonProperty(TEAMS_BACKLOG_SIZE)
         public abstract Builder backlogSize(long backlogSize);
 
+        @JsonProperty(TEAMS_TIME_ZONE)
+        public abstract Builder timeZone(DateTimeZone timeZone);
+
         public abstract TeamsEventNotificationConfig build();
     }
 
@@ -149,6 +159,7 @@ public abstract class TeamsEventNotificationConfig implements EventNotificationC
                 .webhookUrl(ValueReference.of(webhookUrl()))
                 .customMessage(ValueReference.of(customMessage()))
                 .iconUrl(ValueReference.of(iconUrl()))
+                .timeZone(ValueReference.of(timeZone().getID()))
                 .build();
     }
 }

--- a/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationConfigEntity.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationConfigEntity.java
@@ -25,6 +25,7 @@ import org.graylog.events.contentpack.entities.EventNotificationConfigEntity;
 import org.graylog.events.notifications.EventNotificationConfig;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
+import org.joda.time.DateTimeZone;
 
 import java.util.Map;
 
@@ -47,6 +48,9 @@ public abstract class TeamsEventNotificationConfigEntity implements EventNotific
     @JsonProperty(TeamsEventNotificationConfig.TEAMS_ICON_URL)
     public abstract ValueReference iconUrl();
 
+    @JsonProperty(TeamsEventNotificationConfig.TEAMS_TIME_ZONE)
+    public abstract ValueReference timeZone();
+
     public static Builder builder() {
         return Builder.create();
     }
@@ -59,7 +63,8 @@ public abstract class TeamsEventNotificationConfigEntity implements EventNotific
         @JsonCreator
         public static Builder create() {
             return new AutoValue_TeamsEventNotificationConfigEntity.Builder()
-                    .type(TYPE_NAME);
+                    .type(TYPE_NAME)
+                    .timeZone(ValueReference.of("UTC"));
         }
 
         @JsonProperty(TeamsEventNotificationConfig.TEAMS_COLOR)
@@ -74,6 +79,9 @@ public abstract class TeamsEventNotificationConfigEntity implements EventNotific
         @JsonProperty(TeamsEventNotificationConfig.TEAMS_ICON_URL)
         public abstract Builder iconUrl(ValueReference iconUrl);
 
+        @JsonProperty(TeamsEventNotificationConfig.TEAMS_TIME_ZONE)
+        public abstract Builder timeZone(ValueReference timeZone);
+
         public abstract TeamsEventNotificationConfigEntity build();
     }
 
@@ -85,6 +93,7 @@ public abstract class TeamsEventNotificationConfigEntity implements EventNotific
                 .customMessage(customMessage().asString(parameters))
                 .customMessage(customMessage().asString(parameters))
                 .iconUrl(iconUrl().asString(parameters))
+                .timeZone(DateTimeZone.forID(timeZone().asString(parameters)))
                 .build();
     }
 }

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationTest.java
@@ -92,7 +92,7 @@ public class SlackEventNotificationTest {
         final ImmutableList<MessageSummary> messageSummaries = generateMessageSummaries(50);
         when(notificationCallbackService.getBacklogForEvent(eventNotificationContext)).thenReturn(messageSummaries);
 
-        slackEventNotification = new SlackEventNotification(notificationCallbackService, new ObjectMapperProvider().get(),
+        slackEventNotification = new SlackEventNotification(notificationCallbackService, new ObjectMapperProvider(),
                 Engine.createEngine(),
                 mockNotificationService,
                 nodeId, mockSlackClient);
@@ -164,7 +164,7 @@ public class SlackEventNotificationTest {
     @Test
     public void getCustomMessageModel() {
         List<MessageSummary> messageSummaries = generateMessageSummaries(50);
-        Map<String, Object> customMessageModel = slackEventNotification.getCustomMessageModel(eventNotificationContext, slackEventNotificationConfig.type(), messageSummaries);
+        Map<String, Object> customMessageModel = slackEventNotification.getCustomMessageModel(eventNotificationContext, slackEventNotificationConfig.type(), messageSummaries, DateTimeZone.UTC);
         //there are 9 keys and two asserts needs to be implemented (backlog,event)
         assertThat(customMessageModel).isNotNull();
         assertThat(customMessageModel.get("event_definition_description")).isEqualTo("Event Definition Test Description");

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationTest.java
@@ -140,8 +140,6 @@ public class SlackEventNotificationTest {
         SlackMessage.Attachment attachment = actual.attachments().iterator().next();
         assertThat(attachment.color()).isEqualTo(expectedColor);
         assertThat(attachment.text()).isEqualTo(expectedAttachmentText);
-        assertThat(attachment.pretext()).isEqualTo(SlackMessage.VALUE_PRETEXT);
-        assertThat(attachment.fallback()).isEqualTo(SlackMessage.VALUE_FALLBACK);
     }
 
     @After
@@ -292,6 +290,38 @@ public class SlackEventNotificationTest {
         //global setting is at N and the eventNotificationContext is null then the message summaries is null
         List<MessageSummary> messageSummaries = slackEventNotification.getMessageBacklog(null, slackConfig);
         assertThat(messageSummaries).isNull();
+    }
+
+    @Test
+    public void testChannelAlertWithNoTitle() throws EventNotificationException {
+        SlackEventNotificationConfig slackConfig = SlackEventNotificationConfig.builder()
+                .includeTitle(false)
+                .notifyChannel(true)
+                .customMessage("A custom message")
+                .iconEmoji("")
+                .iconUrl("")
+                .userName("")
+                .build();
+
+        SlackMessage message = slackEventNotification.createSlackMessage(eventNotificationContext, slackConfig);
+        assertThat(message.attachments().iterator().next().text()).startsWith("@channel");
+        assertThat(message.text()).isNull();
+    }
+
+    @Test
+    public void testChannelAlertWithTitle() throws EventNotificationException {
+        SlackEventNotificationConfig slackConfig = SlackEventNotificationConfig.builder()
+                .includeTitle(true)
+                .notifyChannel(true)
+                .customMessage("A custom message")
+                .iconEmoji("")
+                .iconUrl("")
+                .userName("")
+                .build();
+
+        SlackMessage message = slackEventNotification.createSlackMessage(eventNotificationContext, slackConfig);
+        assertThat(message.attachments().iterator().next().text()).doesNotStartWith("@channel");
+        assertThat(message.text()).startsWith("@channel");
     }
 
     ImmutableList<MessageSummary> generateMessageSummaries(int size) {

--- a/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/SlackEventNotificationTest.java
@@ -100,7 +100,7 @@ public class SlackEventNotificationTest {
     }
 
     private void getDummySlackNotificationConfig() {
-        slackEventNotificationConfig = new AutoValue_SlackEventNotificationConfig.Builder()
+        slackEventNotificationConfig = SlackEventNotificationConfig.builder()
                 .notifyChannel(true)
                 .type(SlackEventNotificationConfig.TYPE_NAME)
                 .color(expectedColor)

--- a/src/test/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationTest.java
+++ b/src/test/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotificationTest.java
@@ -90,7 +90,8 @@ public class TeamsEventNotificationTest {
         final ImmutableList<MessageSummary> messageSummaries = generateMessageSummaries(50);
         when(notificationCallbackService.getBacklogForEvent(eventNotificationContext)).thenReturn(messageSummaries);
 
-        teamsEventNotification = new TeamsEventNotification(notificationCallbackService, new ObjectMapperProvider().get(),
+        teamsEventNotification = new TeamsEventNotification(notificationCallbackService,
+                new ObjectMapperProvider(),
                 Engine.createEngine(),
                 mockNotificationService,
                 nodeId, mockrequestClient);
@@ -161,7 +162,7 @@ public class TeamsEventNotificationTest {
     @Test
     public void getCustomMessageModel() {
         List<MessageSummary> messageSummaries = generateMessageSummaries(50);
-        Map<String, Object> customMessageModel = teamsEventNotification.getCustomMessageModel(eventNotificationContext, teamsEventNotificationConfig.type(), messageSummaries);
+        Map<String, Object> customMessageModel = teamsEventNotification.getCustomMessageModel(eventNotificationContext, teamsEventNotificationConfig.type(), messageSummaries, DateTimeZone.UTC);
         //there are 9 keys and two asserts needs to be implemented (backlog,event)
         assertThat(customMessageModel).isNotNull();
         assertThat(customMessageModel.get("event_definition_description")).isEqualTo("Event Definition Test Description");

--- a/src/web/event-notifications/event-notification-details/SlackNotificationDetails.jsx
+++ b/src/web/event-notifications/event-notification-details/SlackNotificationDetails.jsx
@@ -17,6 +17,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
+
 import { ReadOnlyFormGroup } from 'components/common';
 import { Well } from 'components/bootstrap';
 
@@ -44,6 +45,7 @@ const SlackNotificationDetails = ({ notification }) => (
     <ReadOnlyFormGroup label="Link Names" value={notification.config.link_names} />
     <ReadOnlyFormGroup label="Icon URL" value={notification.config.icon_url} />
     <ReadOnlyFormGroup label="Icon Emoji" value={notification.config.icon_emoji} />
+    <ReadOnlyFormGroup label="Time Zone" value={notification.config.time_zone} />
   </>
 );
 

--- a/src/web/event-notifications/event-notification-details/SlackNotificationDetails.tsx
+++ b/src/web/event-notifications/event-notification-details/SlackNotificationDetails.tsx
@@ -41,6 +41,7 @@ const SlackNotificationDetails: React.FC<SlackNotificationSummaryType> = ({ noti
                        )} />
     <ReadOnlyFormGroup label="Message Backlog Limit" value={notification.config.backlog_size} />
     <ReadOnlyFormGroup label="User Name" value={notification.config.user_name} />
+    <ReadOnlyFormGroup label="Include Title" value={notification.config.include_title} />
     <ReadOnlyFormGroup label="Notify Channel" value={notification.config.notify_channel} />
     <ReadOnlyFormGroup label="Link Names" value={notification.config.link_names} />
     <ReadOnlyFormGroup label="Icon URL" value={notification.config.icon_url} />

--- a/src/web/event-notifications/event-notification-details/SlackNotificationDetails.tsx
+++ b/src/web/event-notifications/event-notification-details/SlackNotificationDetails.tsx
@@ -15,11 +15,11 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 
 import { ReadOnlyFormGroup } from 'components/common';
 import { Well } from 'components/bootstrap';
+import type { SlackNotificationSummaryType } from 'event-notifications/types';
 
 const NewExampleWell = styled(Well)(({ theme }) => css`
   margin-bottom: 5px;
@@ -29,7 +29,7 @@ const NewExampleWell = styled(Well)(({ theme }) => css`
   word-wrap: break-word;
 `);
 
-const SlackNotificationDetails = ({ notification }) => (
+const SlackNotificationDetails: React.FC<SlackNotificationSummaryType> = ({ notification }) => (
   <>
     <ReadOnlyFormGroup label="Webhook URL" value={notification.config.webhook_url} />
     <ReadOnlyFormGroup label="Channel" value={notification.config.channel} />
@@ -40,7 +40,7 @@ const SlackNotificationDetails = ({ notification }) => (
                          </NewExampleWell>
                        )} />
     <ReadOnlyFormGroup label="Message Backlog Limit" value={notification.config.backlog_size} />
-    <ReadOnlyFormGroup label="User Name" value={notification.config.username} />
+    <ReadOnlyFormGroup label="User Name" value={notification.config.user_name} />
     <ReadOnlyFormGroup label="Notify Channel" value={notification.config.notify_channel} />
     <ReadOnlyFormGroup label="Link Names" value={notification.config.link_names} />
     <ReadOnlyFormGroup label="Icon URL" value={notification.config.icon_url} />
@@ -48,9 +48,5 @@ const SlackNotificationDetails = ({ notification }) => (
     <ReadOnlyFormGroup label="Time Zone" value={notification.config.time_zone} />
   </>
 );
-
-SlackNotificationDetails.propTypes = {
-  notification: PropTypes.object.isRequired,
-};
 
 export default SlackNotificationDetails;

--- a/src/web/event-notifications/event-notification-details/TeamsNotificationDetails.tsx
+++ b/src/web/event-notifications/event-notification-details/TeamsNotificationDetails.tsx
@@ -41,6 +41,7 @@ const TeamsNotificationDetails: React.FC<TeamsNotificationSummaryType> = ({ noti
                        )} />
     <ReadOnlyFormGroup label="Message Backlog Limit" value={notification.config.backlog_size} />
     <ReadOnlyFormGroup label="Icon URL" value={notification.config.icon_url} />
+    <ReadOnlyFormGroup label="Time Zone" value={notification.config.time_zone} />
   </>
 );
 

--- a/src/web/event-notifications/event-notification-types/SlackNotificationForm.jsx
+++ b/src/web/event-notifications/event-notification-types/SlackNotificationForm.jsx
@@ -22,17 +22,32 @@ import get from 'lodash/get';
 import camelCase from 'lodash/camelCase';
 
 import { Input, Button, ControlLabel, FormControl, FormGroup, HelpBlock, InputGroup } from 'components/bootstrap';
-import { ColorPickerPopover } from 'components/common';
+import { ColorPickerPopover, TimezoneSelect } from 'components/common';
 import ColorLabel from 'components/sidecars/common/ColorLabel';
 import DocumentationLink from 'components/support/DocumentationLink';
 import { getValueFromInput } from 'util/FormsUtils';
 
 class SlackNotificationForm extends React.Component {
-    static propTypes = {
-      config: PropTypes.shape({
-        color: PropTypes.string,
-        webhook_url: PropTypes.string,
-        channel: PropTypes.string,
+  static propTypes = {
+    config: PropTypes.shape({
+      color: PropTypes.string,
+      webhook_url: PropTypes.string,
+      channel: PropTypes.string,
+      link_names: PropTypes.string,
+      icon_url: PropTypes.string,
+      icon_emoji: PropTypes.string,
+      backlog_size: PropTypes.number,
+      user_name: PropTypes.string,
+      notify_channel: PropTypes.string,
+      custom_message: PropTypes.string,
+      time_zone: PropTypes.string,
+    }).isRequired,
+    validation: PropTypes.shape({
+      failed: PropTypes.bool.isRequired,
+      errors: PropTypes.shape({
+        webhook_url: PropTypes.arrayOf(PropTypes.string),
+        channel: PropTypes.arrayOf(PropTypes.string),
+        color: PropTypes.arrayOf(PropTypes.string),
         link_names: PropTypes.string,
         icon_url: PropTypes.string,
         icon_emoji: PropTypes.string,
@@ -40,32 +55,18 @@ class SlackNotificationForm extends React.Component {
         user_name: PropTypes.string,
         notify_channel: PropTypes.string,
         custom_message: PropTypes.string,
-      }).isRequired,
-      validation: PropTypes.shape({
-        failed: PropTypes.bool.isRequired,
-        errors: PropTypes.shape({
-          webhook_url: PropTypes.arrayOf(PropTypes.string),
-          channel: PropTypes.arrayOf(PropTypes.string),
-          color: PropTypes.arrayOf(PropTypes.string),
-          link_names: PropTypes.string,
-          icon_url: PropTypes.string,
-          icon_emoji: PropTypes.string,
-          backlog_size: PropTypes.number,
-          user_name: PropTypes.string,
-          notify_channel: PropTypes.string,
-          custom_message: PropTypes.string,
-        }),
-        error_context: PropTypes.object,
-      }).isRequired,
-      onChange: PropTypes.func.isRequired,
-    };
+      }),
+      error_context: PropTypes.object,
+    }).isRequired,
+    onChange: PropTypes.func.isRequired,
+  };
 
-    static defaultConfig = {
-      color: '#FF0000',
-      webhook_url: '',
-      channel: '#channel',
-      /* eslint-disable no-template-curly-in-string */
-      custom_message: ''
+  static defaultConfig = {
+    color: '#FF0000',
+    webhook_url: '',
+    channel: '#channel',
+    /* eslint-disable no-template-curly-in-string */
+    custom_message: ''
                       + '--- [Event Definition] ---------------------------\n'
                       + 'Title:       ${event_definition_title}\n'
                       + 'Type:        ${event_definition_type}\n'
@@ -91,172 +92,183 @@ class SlackNotificationForm extends React.Component {
                       + '${message.message}\n'
                       + '${end}'
                       + '${end}\n',
-      /* eslint-enable no-template-curly-in-string */
-      user_name: 'Graylog',
-      notify_channel: false,
-      link_names: false,
-      icon_url: '',
-      icon_emoji: '',
-      backlog_size: 0,
+    /* eslint-enable no-template-curly-in-string */
+    user_name: 'Graylog',
+    notify_channel: false,
+    link_names: false,
+    icon_url: '',
+    icon_emoji: '',
+    backlog_size: 0,
+    time_zone: 'UTC',
+  };
 
+  constructor(props) {
+    super(props);
+
+    const defaultBacklogSize = props.config.backlog_size;
+
+    this.state = {
+      isBacklogSizeEnabled: defaultBacklogSize > 0,
+      backlogSize: defaultBacklogSize,
     };
+  }
 
-    constructor(props) {
-      super(props);
+  handleBacklogSizeChange = (event) => {
+    const { name } = event.target;
+    const value = getValueFromInput(event.target);
 
-      const defaultBacklogSize = props.config.backlog_size;
+    this.setState({ [camelCase(name)]: value });
+    this.propagateChange(name, getValueFromInput(event.target));
+  };
 
-      this.state = {
-        isBacklogSizeEnabled: defaultBacklogSize > 0,
-        backlogSize: defaultBacklogSize,
-      };
-    }
+  toggleBacklogSize = () => {
+    const { isBacklogSizeEnabled, backlogSize } = this.state;
 
-    handleBacklogSizeChange = (event) => {
-      const { name } = event.target;
-      const value = getValueFromInput(event.target);
+    this.setState({ isBacklogSizeEnabled: !isBacklogSizeEnabled });
+    this.propagateChange('backlog_size', (isBacklogSizeEnabled ? 0 : backlogSize));
+  };
 
-      this.setState({ [camelCase(name)]: value });
-      this.propagateChange(name, getValueFromInput(event.target));
-    };
+  propagateChange = (key, value) => {
+    const { config, onChange } = this.props;
+    const nextConfig = cloneDeep(config);
+    nextConfig[key] = value;
+    onChange(nextConfig);
+  };
 
-    toggleBacklogSize = () => {
-      const { isBacklogSizeEnabled, backlogSize } = this.state;
+  handleColorChange = (color, _, hidePopover) => {
+    hidePopover();
+    this.propagateChange('color', color);
+  };
 
-      this.setState({ isBacklogSizeEnabled: !isBacklogSizeEnabled });
-      this.propagateChange('backlog_size', (isBacklogSizeEnabled ? 0 : backlogSize));
-    };
+  handleChange = (event) => {
+    const { name } = event.target;
+    this.propagateChange(name, getValueFromInput(event.target));
+  };
 
-    propagateChange = (key, value) => {
-      const { config, onChange } = this.props;
-      const nextConfig = cloneDeep(config);
-      nextConfig[key] = value;
-      onChange(nextConfig);
-    };
+  handleTimeZoneChange = (nextValue) => {
+    this.propagateChange('time_zone', nextValue);
+  };
 
-    handleColorChange = (color, _, hidePopover) => {
-      hidePopover();
-      this.propagateChange('color', color);
-    };
+  render() {
+    const { config, validation } = this.props;
+    const { isBacklogSizeEnabled, backlogSize } = this.state;
+    const element = <p>Custom message to be appended below the alert title. See <DocumentationLink text="docs" page="alerts#notifications" /> for more details.</p>;
 
-    handleChange = (event) => {
-      const { name } = event.target;
-      this.propagateChange(name, getValueFromInput(event.target));
-    };
+    return (
+      <>
 
-    render() {
-      const { config, validation } = this.props;
-      const { isBacklogSizeEnabled, backlogSize } = this.state;
-      const element = <p>Custom message to be appended below the alert title. See <DocumentationLink text="docs" page="alerts#notifications" /> for more details.</p>;
-
-      return (
-        <>
-
-          <FormGroup controlId="color">
-            <ControlLabel>Configuration color</ControlLabel>
-            <div>
-              <ColorLabel color={config.color} />
-              <div style={{ display: 'inline-block', marginLeft: 15 }}>
-                <ColorPickerPopover id="color"
-                                    name="color"
-                                    color={config.color || '#f06292'}
-                                    placement="right"
-                                    triggerNode={<Button bsSize="xsmall">Change color</Button>}
-                                    onChange={this.handleColorChange} />
-              </div>
+        <FormGroup controlId="color">
+          <ControlLabel>Configuration color</ControlLabel>
+          <div>
+            <ColorLabel color={config.color} />
+            <div style={{ display: 'inline-block', marginLeft: 15 }}>
+              <ColorPickerPopover id="color"
+                                  name="color"
+                                  color={config.color || '#f06292'}
+                                  placement="right"
+                                  triggerNode={<Button bsSize="xsmall">Change color</Button>}
+                                  onChange={this.handleColorChange} />
             </div>
-            <HelpBlock>Choose a color to use for this configuration.</HelpBlock>
-          </FormGroup>
-          <Input id="notification-webhookUrl"
-                 name="webhook_url"
-                 label="Webhook URL"
-                 type="text"
-                 bsStyle={validation.errors.webhook_url ? 'error' : null}
-                 help={get(validation, 'errors.webhook_url[0]', 'Slack "Incoming Webhook" URL')}
-                 value={config.webhook_url || ''}
-                 onChange={this.handleChange}
-                 required />
-          <Input id="notification-channel"
-                 name="channel"
-                 label="Channel"
-                 type="text"
-                 bsStyle={validation.errors.channel ? 'error' : null}
-                 help={get(validation, 'errors.channel[0]', 'Name of Slack #channel or @user for a direct message')}
-                 value={config.channel || ''}
-                 onChange={this.handleChange}
-                 required />
-          <Input id="notification-customMessage"
-                 name="custom_message"
-                 label="Custom Message (optional)"
-                 type="textarea"
-                 bsStyle={validation.errors.custom_message ? 'error' : null}
-                 help={get(validation, 'errors.custom_message[0]', element)}
-                 value={config.custom_message || ''}
-                 onChange={this.handleChange} />
+          </div>
+          <HelpBlock>Choose a color to use for this configuration.</HelpBlock>
+        </FormGroup>
+        <Input id="notification-webhookUrl"
+               name="webhook_url"
+               label="Webhook URL"
+               type="text"
+               bsStyle={validation.errors.webhook_url ? 'error' : null}
+               help={get(validation, 'errors.webhook_url[0]', 'Slack "Incoming Webhook" URL')}
+               value={config.webhook_url || ''}
+               onChange={this.handleChange}
+               required />
+        <Input id="notification-channel"
+               name="channel"
+               label="Channel"
+               type="text"
+               bsStyle={validation.errors.channel ? 'error' : null}
+               help={get(validation, 'errors.channel[0]', 'Name of Slack #channel or @user for a direct message')}
+               value={config.channel || ''}
+               onChange={this.handleChange}
+               required />
+        <Input id="notification-customMessage"
+               name="custom_message"
+               label="Custom Message (optional)"
+               type="textarea"
+               bsStyle={validation.errors.custom_message ? 'error' : null}
+               help={get(validation, 'errors.custom_message[0]', element)}
+               value={config.custom_message || ''}
+               onChange={this.handleChange} />
+        <Input id="notification-time-zone"
+               help="Time zone used for timestamps in the notification body."
+               label="Time zone for date/time values (optional)">
+          <TimezoneSelect className="timezone-select"
+                          name="time_zone"
+                          value={config.time_zone}
+                          onChange={this.handleTimeZoneChange} />
+        </Input>
+        <FormGroup>
+          <ControlLabel>Message Backlog Limit (optional)</ControlLabel>
+          <InputGroup>
+            <InputGroup.Addon>
+              <input id="toggle_backlog_size"
+                     type="checkbox"
+                     checked={isBacklogSizeEnabled}
+                     onChange={this.toggleBacklogSize} />
+            </InputGroup.Addon>
+            <FormControl type="number"
+                         id="backlog_size"
+                         name="backlog_size"
+                         onChange={this.handleBacklogSizeChange}
+                         value={backlogSize}
+                         min="0"
+                         disabled={!isBacklogSizeEnabled} />
+          </InputGroup>
+          <HelpBlock>Limit the number of backlog messages sent as part of the Slack notification.  If set to 0, no limit will be enforced.</HelpBlock>
+        </FormGroup>
 
-          <FormGroup>
-            <ControlLabel>Message Backlog Limit (optional)</ControlLabel>
-            <InputGroup>
-              <InputGroup.Addon>
-                <input id="toggle_backlog_size"
-                       type="checkbox"
-                       checked={isBacklogSizeEnabled}
-                       onChange={this.toggleBacklogSize} />
-              </InputGroup.Addon>
-              <FormControl type="number"
-                           id="backlog_size"
-                           name="backlog_size"
-                           onChange={this.handleBacklogSizeChange}
-                           value={backlogSize}
-                           min="0"
-                           disabled={!isBacklogSizeEnabled} />
-            </InputGroup>
-            <HelpBlock>Limit the number of backlog messages sent as part of the Slack notification.  If set to 0, no limit will be enforced.</HelpBlock>
-          </FormGroup>
-
-          <Input id="notification-userName"
-                 name="user_name"
-                 label="User Name (optional)"
-                 type="text"
-                 bsStyle={validation.errors.user_name ? 'error' : null}
-                 help={get(validation, 'errors.user_name[0]', 'User name of the sender in Slack')}
-                 value={config.user_name || ''}
-                 onChange={this.handleChange} />
-          <Input id="notification-notifyChannel"
-                 name="notify_channel"
-                 label="Notify Channel (optional)"
-                 type="checkbox"
-                 bsStyle={validation.errors.notify_channel ? 'error' : null}
-                 help={get(validation, 'errors.notify_channel[0]', 'Notify all users in channel by adding @channel to the message')}
-                 checked={config.notify_channel || ''}
-                 onChange={this.handleChange} />
-          <Input id="notification-linkNames"
-                 name="link_names"
-                 label="Link Names (optional)"
-                 type="checkbox"
-                 bsStyle={validation.errors.link_names ? 'error' : null}
-                 help={get(validation, 'errors.link_names[0]', 'Find and link channel names and user names')}
-                 checked={config.link_names || ''}
-                 onChange={this.handleChange} />
-          <Input id="notification-iconUrl"
-                 name="icon_url"
-                 label="Icon URL (optional)"
-                 type="text"
-                 bsStyle={validation.errors.icon_url ? 'error' : null}
-                 help={get(validation, 'errors.icon_url[0]', 'Image to use as the icon for this message')}
-                 value={config.icon_url || ''}
-                 onChange={this.handleChange} />
-          <Input id="notification-iconEmoji"
-                 name="icon_emoji"
-                 label="Icon Emoji (optional)"
-                 type="text"
-                 bsStyle={validation.errors.icon_emoji ? 'error' : null}
-                 help={get(validation, 'errors.icon_emoji[0]', 'Emoji to use as the icon for this message (overrides Icon URL)')}
-                 value={config.icon_emoji || ''}
-                 onChange={this.handleChange} />
-        </>
-      );
-    }
+        <Input id="notification-userName"
+               name="user_name"
+               label="User Name (optional)"
+               type="text"
+               bsStyle={validation.errors.user_name ? 'error' : null}
+               help={get(validation, 'errors.user_name[0]', 'User name of the sender in Slack')}
+               value={config.user_name || ''}
+               onChange={this.handleChange} />
+        <Input id="notification-notifyChannel"
+               name="notify_channel"
+               label="Notify Channel (optional)"
+               type="checkbox"
+               bsStyle={validation.errors.notify_channel ? 'error' : null}
+               help={get(validation, 'errors.notify_channel[0]', 'Notify all users in channel by adding @channel to the message')}
+               checked={config.notify_channel || ''}
+               onChange={this.handleChange} />
+        <Input id="notification-linkNames"
+               name="link_names"
+               label="Link Names (optional)"
+               type="checkbox"
+               bsStyle={validation.errors.link_names ? 'error' : null}
+               help={get(validation, 'errors.link_names[0]', 'Find and link channel names and user names')}
+               checked={config.link_names || ''}
+               onChange={this.handleChange} />
+        <Input id="notification-iconUrl"
+               name="icon_url"
+               label="Icon URL (optional)"
+               type="text"
+               bsStyle={validation.errors.icon_url ? 'error' : null}
+               help={get(validation, 'errors.icon_url[0]', 'Image to use as the icon for this message')}
+               value={config.icon_url || ''}
+               onChange={this.handleChange} />
+        <Input id="notification-iconEmoji"
+               name="icon_emoji"
+               label="Icon Emoji (optional)"
+               type="text"
+               bsStyle={validation.errors.icon_emoji ? 'error' : null}
+               help={get(validation, 'errors.icon_emoji[0]', 'Emoji to use as the icon for this message (overrides Icon URL)')}
+               value={config.icon_emoji || ''}
+               onChange={this.handleChange} />
+      </>
+    );
+  }
 }
 
 export default SlackNotificationForm;

--- a/src/web/event-notifications/event-notification-types/SlackNotificationForm.tsx
+++ b/src/web/event-notifications/event-notification-types/SlackNotificationForm.tsx
@@ -172,11 +172,12 @@ class SlackNotificationForm extends React.Component<Props, any> {
                onChange={this.handleChange} />
         <Input id="notification-time-zone"
                help="Time zone used for timestamps in the notification body."
-               label="Time zone for date/time values (optional)">
+               label="Time zone for date/time values">
           <TimezoneSelect className="timezone-select"
                           name="time_zone"
                           value={config.time_zone}
-                          onChange={this.handleTimeZoneChange} />
+                          onChange={this.handleTimeZoneChange}
+                          clearable={false} />
         </Input>
         <FormGroup>
           <ControlLabel>Message Backlog Limit (optional)</ControlLabel>

--- a/src/web/event-notifications/event-notification-types/SlackNotificationForm.tsx
+++ b/src/web/event-notifications/event-notification-types/SlackNotificationForm.tsx
@@ -20,7 +20,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
 import camelCase from 'lodash/camelCase';
 
-import { Input, Button, ControlLabel, FormControl, FormGroup, HelpBlock, InputGroup } from 'components/bootstrap';
+import { Col, Input, Button, ControlLabel, FormControl, FormGroup, HelpBlock, InputGroup, Row } from 'components/bootstrap';
 import { ColorPickerPopover, TimezoneSelect } from 'components/common';
 import ColorLabel from 'components/sidecars/common/ColorLabel';
 import DocumentationLink from 'components/support/DocumentationLink';
@@ -206,21 +206,38 @@ class SlackNotificationForm extends React.Component<Props, any> {
                help={get(validation, 'errors.user_name[0]', 'User name of the sender in Slack')}
                value={config.user_name || ''}
                onChange={this.handleChange} />
-        <Input id="include_title"
-               name="include_title"
-               label="Include Title"
-               help={get(validation, 'errors.include_title[0]', 'Include the event definition title and description in the notification')}
-               type="checkbox"
-               checked={config.include_title}
-               onChange={this.handleChange} />
-        <Input id="notification-notifyChannel"
-               name="notify_channel"
-               label="Notify Channel"
-               type="checkbox"
-               bsStyle={validation.errors.notify_channel ? 'error' : null}
-               help={get(validation, 'errors.notify_channel[0]', 'Notify all users in channel by adding @channel to the message')}
-               checked={config.notify_channel || ''}
-               onChange={this.handleChange} />
+        <Row>
+          <Col md={4}>
+            <Input id="include_title"
+                   name="include_title"
+                   label="Include Title"
+                   bsStyle={validation.errors.include_title ? 'error' : null}
+                   help={get(validation, 'errors.include_title[0]', 'Include the event definition title and description in the notification')}
+                   type="checkbox"
+                   checked={config.include_title}
+                   onChange={this.handleChange} />
+          </Col>
+          <Col md={4}>
+            <Input id="notification-notifyChannel"
+                   name="notify_channel"
+                   label="Notify Channel"
+                   type="checkbox"
+                   bsStyle={validation.errors.notify_channel ? 'error' : null}
+                   help={get(validation, 'errors.notify_channel[0]', 'Notify all users in channel by adding @channel to the message')}
+                   checked={config.notify_channel || ''}
+                   onChange={this.handleChange} />
+          </Col>
+          <Col md={4}>
+            <Input id="notification-notifyHere"
+                   name="notify_here"
+                   label="Notify Here"
+                   type="checkbox"
+                   bsStyle={validation.errors.notify_here ? 'error' : null}
+                   help={get(validation, 'errors.notify_here[0]', 'Notify active users in channel by adding @here to the message')}
+                   checked={config.notify_here || ''}
+                   onChange={this.handleChange} />
+          </Col>
+        </Row>
         <Input id="notification-linkNames"
                name="link_names"
                label="Link Names"

--- a/src/web/event-notifications/event-notification-types/SlackNotificationForm.tsx
+++ b/src/web/event-notifications/event-notification-types/SlackNotificationForm.tsx
@@ -16,7 +16,6 @@
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import cloneDeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
 import camelCase from 'lodash/camelCase';
@@ -26,41 +25,15 @@ import { ColorPickerPopover, TimezoneSelect } from 'components/common';
 import ColorLabel from 'components/sidecars/common/ColorLabel';
 import DocumentationLink from 'components/support/DocumentationLink';
 import { getValueFromInput } from 'util/FormsUtils';
+import type { SlackConfigType, SlackValidationType } from 'event-notifications/types';
 
-class SlackNotificationForm extends React.Component {
-  static propTypes = {
-    config: PropTypes.shape({
-      color: PropTypes.string,
-      webhook_url: PropTypes.string,
-      channel: PropTypes.string,
-      link_names: PropTypes.string,
-      icon_url: PropTypes.string,
-      icon_emoji: PropTypes.string,
-      backlog_size: PropTypes.number,
-      user_name: PropTypes.string,
-      notify_channel: PropTypes.string,
-      custom_message: PropTypes.string,
-      time_zone: PropTypes.string,
-    }).isRequired,
-    validation: PropTypes.shape({
-      failed: PropTypes.bool.isRequired,
-      errors: PropTypes.shape({
-        webhook_url: PropTypes.arrayOf(PropTypes.string),
-        channel: PropTypes.arrayOf(PropTypes.string),
-        color: PropTypes.arrayOf(PropTypes.string),
-        link_names: PropTypes.string,
-        icon_url: PropTypes.string,
-        icon_emoji: PropTypes.string,
-        backlog_size: PropTypes.number,
-        user_name: PropTypes.string,
-        notify_channel: PropTypes.string,
-        custom_message: PropTypes.string,
-      }),
-      error_context: PropTypes.object,
-    }).isRequired,
-    onChange: PropTypes.func.isRequired,
-  };
+type Props = {
+  config: SlackConfigType,
+  validation: SlackValidationType,
+  onChange: any,
+};
 
+class SlackNotificationForm extends React.Component<Props, any> {
   static defaultConfig = {
     color: '#FF0000',
     webhook_url: '',
@@ -163,7 +136,6 @@ class SlackNotificationForm extends React.Component {
             <ColorLabel color={config.color} />
             <div style={{ display: 'inline-block', marginLeft: 15 }}>
               <ColorPickerPopover id="color"
-                                  name="color"
                                   color={config.color || '#f06292'}
                                   placement="right"
                                   triggerNode={<Button bsSize="xsmall">Change color</Button>}

--- a/src/web/event-notifications/event-notification-types/SlackNotificationForm.tsx
+++ b/src/web/event-notifications/event-notification-types/SlackNotificationForm.tsx
@@ -206,9 +206,16 @@ class SlackNotificationForm extends React.Component<Props, any> {
                help={get(validation, 'errors.user_name[0]', 'User name of the sender in Slack')}
                value={config.user_name || ''}
                onChange={this.handleChange} />
+        <Input id="include_title"
+               name="include_title"
+               label="Include Title"
+               help={get(validation, 'errors.include_title[0]', 'Include the event definition title and description in the notification')}
+               type="checkbox"
+               checked={config.include_title}
+               onChange={this.handleChange} />
         <Input id="notification-notifyChannel"
                name="notify_channel"
-               label="Notify Channel (optional)"
+               label="Notify Channel"
                type="checkbox"
                bsStyle={validation.errors.notify_channel ? 'error' : null}
                help={get(validation, 'errors.notify_channel[0]', 'Notify all users in channel by adding @channel to the message')}
@@ -216,7 +223,7 @@ class SlackNotificationForm extends React.Component<Props, any> {
                onChange={this.handleChange} />
         <Input id="notification-linkNames"
                name="link_names"
-               label="Link Names (optional)"
+               label="Link Names"
                type="checkbox"
                bsStyle={validation.errors.link_names ? 'error' : null}
                help={get(validation, 'errors.link_names[0]', 'Find and link channel names and user names')}

--- a/src/web/event-notifications/event-notification-types/SlackNotificationSummary.jsx
+++ b/src/web/event-notifications/event-notification-types/SlackNotificationSummary.jsx
@@ -16,6 +16,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import CommonNotificationSummary from 'components/event-notifications/event-notification-types/CommonNotificationSummary';
 
 function SlackNotificationSummary({ notification, ...restProps }) {
@@ -36,6 +37,10 @@ function SlackNotificationSummary({ notification, ...restProps }) {
       <tr>
         <td>Custom Message</td>
         <td>{notification.config.custom_message}</td>
+      </tr>
+      <tr>
+        <td>Time Zone</td>
+        <td>{notification.config.time_zone}</td>
       </tr>
       <tr>
         <td>Message Backlog Limit</td>
@@ -84,7 +89,7 @@ SlackNotificationSummary.propTypes = {
       channel: PropTypes.string,
       webhook_url: PropTypes.string,
       color: PropTypes.string,
-
+      time_zone: PropTypes.string,
     }).isRequired,
 
   }),

--- a/src/web/event-notifications/event-notification-types/SlackNotificationSummary.tsx
+++ b/src/web/event-notifications/event-notification-types/SlackNotificationSummary.tsx
@@ -35,6 +35,10 @@ function SlackNotificationSummary({ notification, ...restProps }: SlackNotificat
         <td>{notification.config.channel}</td>
       </tr>
       <tr>
+        <td>Include Title</td>
+        <td>{notification.config.include_title}</td>
+      </tr>
+      <tr>
         <td>Custom Message</td>
         <td>{notification.config.custom_message}</td>
       </tr>

--- a/src/web/event-notifications/event-notification-types/SlackNotificationSummary.tsx
+++ b/src/web/event-notifications/event-notification-types/SlackNotificationSummary.tsx
@@ -15,11 +15,11 @@
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import CommonNotificationSummary from 'components/event-notifications/event-notification-types/CommonNotificationSummary';
+import type { SlackNotificationSummaryType } from 'event-notifications/types';
 
-function SlackNotificationSummary({ notification, ...restProps }) {
+function SlackNotificationSummary({ notification, ...restProps }: SlackNotificationSummaryType) {
   return (
     <CommonNotificationSummary {...restProps} notification={notification}>
       <tr>
@@ -66,35 +66,9 @@ function SlackNotificationSummary({ notification, ...restProps }) {
         <td>Icon Emoji</td>
         <td>{notification.config.icon_emoji}</td>
       </tr>
-      <tr>
-        <td>Graylog URL</td>
-        <td>{notification.config.graylog_url}</td>
-      </tr>
     </CommonNotificationSummary>
   );
 }
-
-SlackNotificationSummary.propTypes = {
-  type: PropTypes.string.isRequired,
-  notification: PropTypes.shape({
-    config: PropTypes.shape({
-      graylog_url: PropTypes.string,
-      icon_emoji: PropTypes.string,
-      icon_url: PropTypes.string,
-      link_names: PropTypes.string,
-      notify_channel: PropTypes.string,
-      backlog_size: PropTypes.number,
-      user_name: PropTypes.string,
-      custom_message: PropTypes.string,
-      channel: PropTypes.string,
-      webhook_url: PropTypes.string,
-      color: PropTypes.string,
-      time_zone: PropTypes.string,
-    }).isRequired,
-
-  }),
-  definitionNotification: PropTypes.object.isRequired,
-};
 
 SlackNotificationSummary.defaultProps = {
   notification: {},

--- a/src/web/event-notifications/event-notification-types/TeamsNotificationForm.tsx
+++ b/src/web/event-notifications/event-notification-types/TeamsNotificationForm.tsx
@@ -166,11 +166,12 @@ class TeamsNotificationForm extends React.Component<TeamsNotificationFormType, a
         <FormGroup>
           <Input id="notification-time-zone"
                  help="Time zone used for timestamps in the notification body."
-                 label="Time zone for date/time values (optional)">
+                 label="Time zone for date/time values">
             <TimezoneSelect className="timezone-select"
                             name="time_zone"
                             value={config.time_zone}
-                            onChange={this.handleTimeZoneChange} />
+                            onChange={this.handleTimeZoneChange}
+                            clearable={false} />
           </Input>
           <ControlLabel>Message Backlog Limit (optional)</ControlLabel>
           <InputGroup>

--- a/src/web/event-notifications/event-notification-types/TeamsNotificationForm.tsx
+++ b/src/web/event-notifications/event-notification-types/TeamsNotificationForm.tsx
@@ -21,7 +21,7 @@ import camelCase from 'lodash/camelCase';
 
 import { getValueFromInput } from 'util/FormsUtils';
 import { Input, Button, ControlLabel, FormControl, FormGroup, HelpBlock, InputGroup } from 'components/bootstrap';
-import { ColorPickerPopover } from 'components/common';
+import { ColorPickerPopover, TimezoneSelect } from 'components/common';
 import ColorLabel from 'components/sidecars/common/ColorLabel';
 
 import type { ConfigType, ValidationType } from '../types';
@@ -72,7 +72,7 @@ class TeamsNotificationForm extends React.Component<TeamsNotificationFormType, a
     /* eslint-enable no-template-curly-in-string */
     icon_url: '',
     backlog_size: 0,
-
+    time_zone: 'UTC',
   };
 
   constructor(props: TeamsNotificationFormType | Readonly<TeamsNotificationFormType>) {
@@ -111,6 +111,10 @@ class TeamsNotificationForm extends React.Component<TeamsNotificationFormType, a
   handleColorChange: (color: string, _: any, hidePopover: any) => void = (color, _, hidePopover) => {
     hidePopover();
     this.propagateChange('color', color);
+  };
+
+  handleTimeZoneChange = (nextValue) => {
+    this.propagateChange('time_zone', nextValue);
   };
 
   handleChange = (event: { target: { name: any; }; }) => {
@@ -160,6 +164,14 @@ class TeamsNotificationForm extends React.Component<TeamsNotificationFormType, a
                onChange={this.handleChange} />
 
         <FormGroup>
+          <Input id="notification-time-zone"
+                 help="Time zone used for timestamps in the notification body."
+                 label="Time zone for date/time values (optional)">
+            <TimezoneSelect className="timezone-select"
+                            name="time_zone"
+                            value={config.time_zone}
+                            onChange={this.handleTimeZoneChange} />
+          </Input>
           <ControlLabel>Message Backlog Limit (optional)</ControlLabel>
           <InputGroup>
             <InputGroup.Addon>

--- a/src/web/event-notifications/event-notification-types/TeamsNotificationSummary.tsx
+++ b/src/web/event-notifications/event-notification-types/TeamsNotificationSummary.tsx
@@ -37,6 +37,10 @@ function TeamsNotificationSummary({ notification, ...restProps }: TeamsNotificat
         <td>{notification.config.custom_message}</td>
       </tr>
       <tr>
+        <td>Time Zone</td>
+        <td>{notification.config.time_zone}</td>
+      </tr>
+      <tr>
         <td>Message Backlog Limit</td>
         <td>{notification.config.backlog_size}</td>
       </tr>

--- a/src/web/event-notifications/event-notification-types/TeamsNotificationSummary.tsx
+++ b/src/web/event-notifications/event-notification-types/TeamsNotificationSummary.tsx
@@ -48,10 +48,6 @@ function TeamsNotificationSummary({ notification, ...restProps }: TeamsNotificat
         <td>Icon URL</td>
         <td>{notification.config.icon_url}</td>
       </tr>
-      <tr>
-        <td>Graylog URL</td>
-        <td>{notification.config.graylog_url}</td>
-      </tr>
     </CommonNotificationSummary>
   );
 }

--- a/src/web/event-notifications/types.ts
+++ b/src/web/event-notifications/types.ts
@@ -25,7 +25,6 @@ export type NotificationType = {
 
 export interface ConfigType {
     defaultValue?: any,
-    graylog_url?: string,
     icon_url?: string,
     backlog_size?: number,
     custom_message: string,
@@ -45,4 +44,48 @@ export interface ErrorType {
     icon_url: string,
     backlog_size: number,
     custom_message: string,
+}
+
+export type SlackNotificationSummaryType = {
+    type: string,
+    notification: SlackNotificationType,
+    definitionNotification: any,
+}
+
+export type SlackNotificationType = {
+    config: SlackConfigType,
+}
+
+export interface SlackConfigType {
+    icon_emoji?: string,
+    icon_url?: string,
+    link_names: string,
+    notify_channel: string,
+    backlog_size: number,
+    user_name?: string,
+    custom_message: string,
+    channel: string,
+    webhook_url: string,
+    color: string,
+    time_zone: string,
+}
+
+export type SlackValidationType = {
+    failed: boolean,
+    errors?: SlackErrorType,
+    error_context?: any
+}
+
+export interface SlackErrorType {
+    icon_emoji?: string,
+    icon_url?: string,
+    link_names: string,
+    notify_channel: string,
+    backlog_size: number,
+    user_name?: string,
+    custom_message: string,
+    channel: string,
+    webhook_url: string,
+    color: string,
+    time_zone: string,
 }

--- a/src/web/event-notifications/types.ts
+++ b/src/web/event-notifications/types.ts
@@ -68,6 +68,7 @@ export interface SlackConfigType {
     webhook_url: string,
     color: string,
     time_zone: string,
+    include_title: boolean,
 }
 
 export type SlackValidationType = {

--- a/src/web/event-notifications/types.ts
+++ b/src/web/event-notifications/types.ts
@@ -60,7 +60,8 @@ export interface SlackConfigType {
     icon_emoji?: string,
     icon_url?: string,
     link_names: string,
-    notify_channel: string,
+    notify_channel: boolean,
+    notify_here: boolean,
     backlog_size: number,
     user_name?: string,
     custom_message: string,
@@ -82,6 +83,7 @@ export interface SlackErrorType {
     icon_url?: string,
     link_names: string,
     notify_channel: string,
+    notify_here: string,
     backlog_size: number,
     user_name?: string,
     custom_message: string,
@@ -89,4 +91,5 @@ export interface SlackErrorType {
     webhook_url: string,
     color: string,
     time_zone: string,
+    include_title?: string,
 }

--- a/src/web/event-notifications/types.ts
+++ b/src/web/event-notifications/types.ts
@@ -31,6 +31,7 @@ export interface ConfigType {
     custom_message: string,
     webhook_url?: string,
     color?: string,
+    time_zone?: string,
 }
 
 export type ValidationType = {


### PR DESCRIPTION
- Support time zones for Slack and Teams notifications (closes #1318)
  - Date times included in notifications should now be formatted with the configured time zone
  - Default time zone of UTC provided for existing notifications should ensure backwards compatibility
- Adds option to omit the title portion of a Slack notification to reduce clutter (closes #1172)
- Convert existing JSX files to TSX files - does not include a conversion to functional components.
  - Also removed a seemingly unused `graylog_url` config property
- Add support for notifying `@here` in Slack notifications instead of just `@channel` (closes #780)
  - Note that support is for EITHER channel OR here, not both

All of these changes should be backwards compatible and test successfully with existing MS Teams and Slack notifications

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

