### PR TITLE
Fix field parsing for Global Protect 9.1.3 template

### DIFF
--- a/changelog/unreleased/issue-1327.toml
+++ b/changelog/unreleased/issue-1327.toml
@@ -1,5 +1,7 @@
 type = "fixed"
 message = "Fixed issue with Palo Alto Global Protect logs parsing last 5 fields incorrectly."
 
-issues = ["1327"]
+issues = ["1327", "Graylog2/graylog2-server#14363"]
 pulls = ["1328"]
+
+contributors = ["@giveen"]

--- a/changelog/unreleased/issue-1327.toml
+++ b/changelog/unreleased/issue-1327.toml
@@ -1,0 +1,5 @@
+type = "fixed"
+message = "Fixed issue with Palo Alto Global Protect logs parsing last 5 fields incorrectly."
+
+issues = ["1327"]
+pulls = ["1328"]

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xTemplates.java
@@ -262,12 +262,13 @@ public class PaloAlto9xTemplates {
         fields.add(create(EventFields.EVENT_UID, 34, STRING));
 
         fields.add(create(PaloAlto9xFields.PAN_LOG_PANORAMA, 35, STRING));
-        fields.add(create(PaloAlto9xFields.PAN_SELECTION_TYPE, 36, STRING));
-        fields.add(create(ApplicationFields.APPLICATION_RESPONSE_TIME, 37, LONG));
-        fields.add(create(PaloAlto9xFields.PAN_GATEWAY_PRIORITY, 38, LONG));
-        fields.add(create(PaloAlto9xFields.PAN_ATTEMPTED_GATEWAYS, 39, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_HIGH_RES_TIME, 36, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_SELECTION_TYPE, 37, STRING));
+        fields.add(create(ApplicationFields.APPLICATION_RESPONSE_TIME, 38, LONG));
+        fields.add(create(PaloAlto9xFields.PAN_GATEWAY_PRIORITY, 39, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_ATTEMPTED_GATEWAYS, 40, STRING));
 
-        fields.add(create(PaloAlto9xFields.PAN_GATEWAY, 40, STRING));
+        fields.add(create(PaloAlto9xFields.PAN_GATEWAY, 41, STRING));
 
         return toTemplate(fields);
     }


### PR DESCRIPTION
Closes #1327 
Closes Graylog2/graylog2-server#14363

Relevant links for justification of changes:
[PAN Docs](https://docs.paloaltonetworks.com/pan-os/11-0/pan-os-admin/monitoring/use-syslog-for-monitoring/syslog-field-descriptions/globalprotect-log-fields) show correct log format

[PAN KB Article](https://knowledgebase.paloaltonetworks.com/KCSArticleDetail?id=kA10g000000ClSsCAK) shows priority integer values are related to a priority string value that seems to be being used in log messages
## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

