### PR TITLE
Updating to `react-router` v6.

### DIFF
--- a/src/web/aws/AWSInputConfiguration.jsx
+++ b/src/web/aws/AWSInputConfiguration.jsx
@@ -16,10 +16,11 @@
  */
 import PropTypes from 'prop-types';
 
-import history from 'util/History';
+import useHistory from 'routing/useHistory';
 import Routes from 'aws/common/Routes.js';
 
 const AWSInputConfiguration = ({ url }) => {
+  const history = useHistory();
   history.push(url);
 
   return null;

--- a/src/web/aws/cloudwatch/CloudWatch.jsx
+++ b/src/web/aws/cloudwatch/CloudWatch.jsx
@@ -20,13 +20,13 @@ import PropTypes from 'prop-types';
 import ConfirmLeaveDialog from 'components/common/ConfirmLeaveDialog';
 import Wizard from 'components/common/Wizard';
 import { getValueFromInput } from 'util/FormsUtils.js';
-import history from 'util/History';
 import Routes from 'routing/Routes';
 import StepAuthorize from 'aws/StepAuthorize';
 import { StepsContext } from 'aws/context/Steps';
 import { FormDataContext } from 'aws/context/FormData';
 import { ApiContext } from 'aws/context/Api';
 import { SidebarContext } from 'aws/context/Sidebar';
+import useHistory from 'routing/useHistory';
 
 import StepKinesis from './StepKinesis';
 import StepHealthCheck from './StepHealthCheck';
@@ -47,6 +47,7 @@ const CloudWatch = ({ externalInputSubmit, onSubmit }) => {
   const { sidebar, clearSidebar } = useContext(SidebarContext);
   const [dirty, setDirty] = useState(false);
   const [lastStep, setLastStep] = useState(false);
+  const history = useHistory();
 
   const handleStepChange = (nextStep) => {
     setCurrentStep(nextStep);
@@ -125,7 +126,7 @@ const CloudWatch = ({ externalInputSubmit, onSubmit }) => {
         disabled: isDisabledStep('review'),
       },
     ];
-  }, [availableSteps, availableStreams.length, clearSidebar, currentStep, dirty, isDisabledStep, setCurrentStep, setEnabledStep, setFormData, externalInputSubmit, onSubmit]);
+  }, [isDisabledStep, availableStreams.length, externalInputSubmit, setCurrentStep, dirty, setFormData, clearSidebar, availableSteps, currentStep, setEnabledStep, onSubmit, history]);
 
   useEffect(() => {
     if (availableSteps.length === 0) {

--- a/src/web/aws/cloudwatch/CloudWatch.test.jsx
+++ b/src/web/aws/cloudwatch/CloudWatch.test.jsx
@@ -19,19 +19,18 @@ import { screen, render, waitFor } from 'wrappedTestingLibrary';
 import userEvent from '@testing-library/user-event';
 import { exampleFormDataWithKeySecretAuth } from 'aws/FormData.fixtures';
 
-import { StoreMock as MockStore } from 'helpers/mocking';
-import history from 'util/History';
 import { FormDataProvider } from 'aws/context/FormData';
 import { ApiContext } from 'aws/context/Api';
 import { StepsContext } from 'aws/context/Steps';
 import { SidebarContext } from 'aws/context/Sidebar';
 import Routes from 'routing/Routes';
+import mockHistory from 'helpers/mocking/mockHistory';
+import { asMock } from 'helpers/mocking';
+import useHistory from 'routing/useHistory';
 
 import CloudWatch from './CloudWatch';
 
-const mockCurrentUser = { currentUser: { fullname: 'Ada Lovelace', username: 'ada' } };
-
-jest.mock('util/History');
+jest.mock('routing/useHistory');
 
 // eslint-disable-next-line react/prop-types
 const TestCommonProviders = ({ children }) => (
@@ -56,6 +55,13 @@ const TestCommonProviders = ({ children }) => (
 );
 
 describe('<CloudWatch>', () => {
+  let history;
+
+  beforeEach(() => {
+    history = mockHistory();
+    asMock(useHistory).mockReturnValue(history);
+  });
+
   it('redirects to system/inputs after input is created', async () => {
     render(
       <TestCommonProviders>


### PR DESCRIPTION
This PR is supporting Graylog2/graylog2-server#12911 in migrating to `react-router` v6.