### PR TITLE
skip not configured option for palo alto inputs

### DIFF
--- a/changelog/unreleased/pr-1332.toml
+++ b/changelog/unreleased/pr-1332.toml
@@ -1,0 +1,5 @@
+type = "added"
+message = "Added configurable default timezone to syslogs inputs and parse tz field from FortiGate msg's"
+
+issues = ["Graylog2/graylog2-server#3853"]
+pulls = ["1332", "Graylog2/graylog2-server#14737", "graylog-labs/syslog4j-graylog2#41", ]

--- a/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoCodec.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto/PaloAltoCodec.java
@@ -141,7 +141,7 @@ public class PaloAltoCodec implements Codec {
                     CK_TIMEZONE,
                     TIMEZONE_OFFSET_LABEL,
                     DateTimeZone.UTC.getID(),
-                    DropdownField.ValueTemplates.timeZones(),
+                    DropdownField.ValueTemplates.timeZones(false),
                     TIMEZONE_OFFSET_DESCRIPTION,
                     ConfigurationField.Optional.OPTIONAL));
 

--- a/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodec.java
+++ b/src/main/java/org/graylog/integrations/inputs/paloalto9/PaloAlto9xCodec.java
@@ -167,7 +167,7 @@ public class PaloAlto9xCodec implements Codec {
                     CK_TIMEZONE,
                     "Time Zone",
                     DateTimeZone.UTC.getID(),
-                    DropdownField.ValueTemplates.timeZones(),
+                    DropdownField.ValueTemplates.timeZones(false),
                     "Time zone of the Palo Alto device",
                     ConfigurationField.Optional.OPTIONAL));
 


### PR DESCRIPTION
## Notes for Reviewers
part of https://github.com/Graylog2/graylog2-server/issues/3853
/jenkins-pr-deps Graylog2/graylog2-server#14737

Adding boolean flag to keep functionality as it is for PaloAlto inputs
- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

