### PR TITLE
fix(1334): use navigate in useEffect hook

### DIFF
--- a/src/web/aws/AWSInputConfiguration.jsx
+++ b/src/web/aws/AWSInputConfiguration.jsx
@@ -14,14 +14,18 @@
  * along with this program. If not, see
  * <http://www.mongodb.com/licensing/server-side-public-license>.
  */
+import { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useNavigate } from 'react-router-dom';
 
-import useHistory from 'routing/useHistory';
 import Routes from 'aws/common/Routes.js';
 
 const AWSInputConfiguration = ({ url }) => {
-  const history = useHistory();
-  history.push(url);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    navigate(url);
+  }, [url, navigate]);
 
   return null;
 };

--- a/src/web/aws/cloudwatch/CloudWatch.jsx
+++ b/src/web/aws/cloudwatch/CloudWatch.jsx
@@ -16,6 +16,7 @@
  */
 import React, { useContext, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
+import { useNavigate } from 'react-router-dom';
 
 import ConfirmLeaveDialog from 'components/common/ConfirmLeaveDialog';
 import Wizard from 'components/common/Wizard';
@@ -26,7 +27,7 @@ import { StepsContext } from 'aws/context/Steps';
 import { FormDataContext } from 'aws/context/FormData';
 import { ApiContext } from 'aws/context/Api';
 import { SidebarContext } from 'aws/context/Sidebar';
-import useHistory from 'routing/useHistory';
+// import useHistory from 'routing/useHistory';
 
 import StepKinesis from './StepKinesis';
 import StepHealthCheck from './StepHealthCheck';
@@ -47,7 +48,8 @@ const CloudWatch = ({ externalInputSubmit, onSubmit }) => {
   const { sidebar, clearSidebar } = useContext(SidebarContext);
   const [dirty, setDirty] = useState(false);
   const [lastStep, setLastStep] = useState(false);
-  const history = useHistory();
+  // const history = useHistory();
+  const navigate = useNavigate();
 
   const handleStepChange = (nextStep) => {
     setCurrentStep(nextStep);
@@ -89,7 +91,8 @@ const CloudWatch = ({ externalInputSubmit, onSubmit }) => {
         if (externalInputSubmit) {
           onSubmit(maybeFormData);
         } else {
-          history.push(Routes.SYSTEM.INPUTS);
+          // history.push(Routes.SYSTEM.INPUTS);
+          navigate(Routes.SYSTEM.INPUTS);
         }
       }
     };
@@ -126,7 +129,7 @@ const CloudWatch = ({ externalInputSubmit, onSubmit }) => {
         disabled: isDisabledStep('review'),
       },
     ];
-  }, [isDisabledStep, availableStreams.length, externalInputSubmit, setCurrentStep, dirty, setFormData, clearSidebar, availableSteps, currentStep, setEnabledStep, onSubmit, history]);
+  }, [isDisabledStep, availableStreams.length, externalInputSubmit, setCurrentStep, dirty, setFormData, clearSidebar, availableSteps, currentStep, setEnabledStep, onSubmit, navigate]);
 
   useEffect(() => {
     if (availableSteps.length === 0) {

--- a/src/web/aws/cloudwatch/CloudWatch.test.jsx
+++ b/src/web/aws/cloudwatch/CloudWatch.test.jsx
@@ -24,13 +24,20 @@ import { ApiContext } from 'aws/context/Api';
 import { StepsContext } from 'aws/context/Steps';
 import { SidebarContext } from 'aws/context/Sidebar';
 import Routes from 'routing/Routes';
-import mockHistory from 'helpers/mocking/mockHistory';
-import { asMock } from 'helpers/mocking';
-import useHistory from 'routing/useHistory';
 
 import CloudWatch from './CloudWatch';
 
-jest.mock('routing/useHistory');
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const original = jest.requireActual('react-router-dom');
+
+  return {
+    __esModule: true,
+    ...original,
+    useNavigate: jest.fn(() => mockNavigate),
+  };
+});
 
 // eslint-disable-next-line react/prop-types
 const TestCommonProviders = ({ children }) => (
@@ -55,13 +62,6 @@ const TestCommonProviders = ({ children }) => (
 );
 
 describe('<CloudWatch>', () => {
-  let history;
-
-  beforeEach(() => {
-    history = mockHistory();
-    asMock(useHistory).mockReturnValue(history);
-  });
-
   it('redirects to system/inputs after input is created', async () => {
     render(
       <TestCommonProviders>
@@ -75,9 +75,9 @@ describe('<CloudWatch>', () => {
 
     userEvent.click(submitButton);
 
-    await waitFor(() => expect(history.push).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledTimes(1));
 
-    expect(history.push).toHaveBeenCalledWith(Routes.SYSTEM.INPUTS);
+    expect(mockNavigate).toHaveBeenCalledWith(Routes.SYSTEM.INPUTS);
   });
 
   it('calls onSubmit when input is submitted externally', async () => {


### PR DESCRIPTION
## Notes for Reviewers
Fixes a navigation issue that was causing a race condition where the HOC was expecting a modal view as a form. This input mounts a component that redirects the user to the stepper form view, unmounting the HOC, preventing the call to `this._openModal` on the `onClick` event for the `Lunc new input` button.

/nocl

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

