### PR TITLE
Deprecate GreyNoise Data Adapters

### DIFF
--- a/changelog/unreleased/pr-1340.toml
+++ b/changelog/unreleased/pr-1340.toml
@@ -1,4 +1,4 @@
-type = "d" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+type = "d"
 message = "GreyNoise Data Adapter functionality has been limited to only use with non-community GreyNoise subscriptions."
 
 issues = ["Graylog2/graylog-plugin-enterprise#5157"]

--- a/changelog/unreleased/pr-1340.toml
+++ b/changelog/unreleased/pr-1340.toml
@@ -1,0 +1,11 @@
+type = "d" # One of: a(dded), c(hanged), d(eprecated), r(emoved), f(ixed), s(ecurity)
+message = "GreyNoise Data Adapter functionality has been limited to only use with non-community GreyNoise subscriptions."
+
+issues = ["Graylog2/graylog-plugin-enterprise#5157"]
+pulls = ["1340", "Graylog2/graylog-plugin-enterprise-integrations#1059", "Graylog2/graylog2-server#15592"]
+details.user = """
+- GreyNoise Community IP Lookup Data Adapters have been marked as deprecated. Existing Data Adapters can no longer be
+  started or lookups performed.
+- GreyNoise Full IP Lookup [Enterprise] Data Adapter can no longer be used with a free GreyNoise Community API tokens.
+- GreyNoise Quick IP Lookup Data Adapter can no longer be used with a free GreyNoise Community API tokens.
+"""

--- a/src/main/java/org/graylog/integrations/IntegrationsModule.java
+++ b/src/main/java/org/graylog/integrations/IntegrationsModule.java
@@ -26,6 +26,7 @@ import org.graylog.integrations.aws.resources.AWSResource;
 import org.graylog.integrations.aws.resources.KinesisSetupResource;
 import org.graylog.integrations.aws.transports.AWSTransport;
 import org.graylog.integrations.aws.transports.KinesisTransport;
+import org.graylog.integrations.dataadapters.GreyNoiseCommunityIpLookupAdapter;
 import org.graylog.integrations.dataadapters.GreyNoiseQuickIPDataAdapter;
 import org.graylog.integrations.inputs.paloalto.PaloAltoCodec;
 import org.graylog.integrations.inputs.paloalto.PaloAltoTCPInput;
@@ -133,6 +134,12 @@ public class IntegrationsModule extends PluginModule {
                     GreyNoiseQuickIPDataAdapter.class,
                     GreyNoiseQuickIPDataAdapter.Factory.class,
                     GreyNoiseQuickIPDataAdapter.Config.class);
+
+            //Community GreyNoise IP Lookup Adapter
+            installLookupDataAdapter(GreyNoiseCommunityIpLookupAdapter.ADAPTER_NAME,
+                    GreyNoiseCommunityIpLookupAdapter.class,
+                    GreyNoiseCommunityIpLookupAdapter.Factory.class,
+                    GreyNoiseCommunityIpLookupAdapter.Config.class);
 
             // PagerDuty notification type fix
             addMigration(V20220622071600_MigratePagerDutyV1.class);

--- a/src/main/java/org/graylog/integrations/IntegrationsModule.java
+++ b/src/main/java/org/graylog/integrations/IntegrationsModule.java
@@ -36,7 +36,7 @@ import org.graylog.integrations.ipfix.codecs.IpfixCodec;
 import org.graylog.integrations.ipfix.inputs.IpfixUdpInput;
 import org.graylog.integrations.ipfix.transports.IpfixUdpTransport;
 import org.graylog.integrations.migrations.V20220622071600_MigratePagerDutyV1;
-import org.graylog.integrations.migrations.V20230522201200_RemoveGreyNoiseCommunityDataAdapters;
+import org.graylog.integrations.migrations.V20230522201200_NotificationForDeprecatedGreyNoiseCommunityDataAdapters;
 import org.graylog.integrations.notifications.types.SlackEventNotification;
 import org.graylog.integrations.notifications.types.SlackEventNotificationConfig;
 import org.graylog.integrations.notifications.types.SlackEventNotificationConfigEntity;
@@ -145,7 +145,7 @@ public class IntegrationsModule extends PluginModule {
             addMigration(V20220622071600_MigratePagerDutyV1.class);
 
             // Remove Community GreyNoise IP Lookup Adapters
-            addMigration(V20230522201200_RemoveGreyNoiseCommunityDataAdapters.class);
+            addMigration(V20230522201200_NotificationForDeprecatedGreyNoiseCommunityDataAdapters.class);
         }
     }
 

--- a/src/main/java/org/graylog/integrations/IntegrationsModule.java
+++ b/src/main/java/org/graylog/integrations/IntegrationsModule.java
@@ -26,7 +26,6 @@ import org.graylog.integrations.aws.resources.AWSResource;
 import org.graylog.integrations.aws.resources.KinesisSetupResource;
 import org.graylog.integrations.aws.transports.AWSTransport;
 import org.graylog.integrations.aws.transports.KinesisTransport;
-import org.graylog.integrations.dataadapters.GreyNoiseCommunityIpLookupAdapter;
 import org.graylog.integrations.dataadapters.GreyNoiseQuickIPDataAdapter;
 import org.graylog.integrations.inputs.paloalto.PaloAltoCodec;
 import org.graylog.integrations.inputs.paloalto.PaloAltoTCPInput;
@@ -36,6 +35,7 @@ import org.graylog.integrations.ipfix.codecs.IpfixCodec;
 import org.graylog.integrations.ipfix.inputs.IpfixUdpInput;
 import org.graylog.integrations.ipfix.transports.IpfixUdpTransport;
 import org.graylog.integrations.migrations.V20220622071600_MigratePagerDutyV1;
+import org.graylog.integrations.migrations.V20230522201200_RemoveGreyNoiseCommunityDataAdapters;
 import org.graylog.integrations.notifications.types.SlackEventNotification;
 import org.graylog.integrations.notifications.types.SlackEventNotificationConfig;
 import org.graylog.integrations.notifications.types.SlackEventNotificationConfigEntity;
@@ -134,14 +134,11 @@ public class IntegrationsModule extends PluginModule {
                     GreyNoiseQuickIPDataAdapter.Factory.class,
                     GreyNoiseQuickIPDataAdapter.Config.class);
 
-            //Community GreyNoise IP Lookup Adapter
-            installLookupDataAdapter(GreyNoiseCommunityIpLookupAdapter.ADAPTER_NAME,
-                    GreyNoiseCommunityIpLookupAdapter.class,
-                    GreyNoiseCommunityIpLookupAdapter.Factory.class,
-                    GreyNoiseCommunityIpLookupAdapter.Config.class);
-
             // PagerDuty notification type fix
             addMigration(V20220622071600_MigratePagerDutyV1.class);
+
+            // Remove Community GreyNoise IP Lookup Adapters
+            addMigration(V20230522201200_RemoveGreyNoiseCommunityDataAdapters.class);
         }
     }
 

--- a/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapter.java
+++ b/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapter.java
@@ -119,23 +119,28 @@ public class GreyNoiseCommunityIpLookupAdapter extends LookupDataAdapter {
 
     @Override
     protected LookupResult doGet(Object ipAddress) {
-
-
-        Optional<Request> request = createRequest(ipAddress);
-        if (!request.isPresent()) {
-            return LookupResult.withError();
-        }
-
-        LookupResult result;
-        try (Response response = okHttpClient.newCall(request.get()).execute()) {
-            result = parseResponse(response);
-
-        } catch (IOException e) {
-            LOG.error("an error occurred while retrieving GreyNoise IP data. {}", e.getMessage(), e);
-            result = LookupResult.withError();
-        }
-        return result;
+        return LookupResult.withError("GreyNoise Community IP Lookup Data Adapter is no deprecated and lookups can no longer be performed.");
     }
+
+//    @Override
+//    protected LookupResult doGet(Object ipAddress) {
+//
+//
+//        Optional<Request> request = createRequest(ipAddress);
+//        if (!request.isPresent()) {
+//            return LookupResult.withError();
+//        }
+//
+//        LookupResult result;
+//        try (Response response = okHttpClient.newCall(request.get()).execute()) {
+//            result = parseResponse(response);
+//
+//        } catch (IOException e) {
+//            LOG.error("an error occurred while retrieving GreyNoise IP data. {}", e.getMessage(), e);
+//            result = LookupResult.withError();
+//        }
+//        return result;
+//    }
 
     @VisibleForTesting
     Optional<Request> createRequest(Object ipAddress) {

--- a/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapter.java
+++ b/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapter.java
@@ -65,7 +65,8 @@ import java.util.stream.Collectors;
 @Deprecated
 public class GreyNoiseCommunityIpLookupAdapter extends LookupDataAdapter {
 
-    public static final String ADAPTER_NAME = "GreyNoise Community IP Lookup [Deprecated]";
+    public static final String ADAPTER_NAME = "GreyNoise Community IP Lookup";
+    public static final String DEPRECATED = " [Deprecated]";
 
     protected static final String GREYNOISE_COMMUNITY_ENDPOINT = "https://api.greynoise.io/v3/community";
 
@@ -268,7 +269,7 @@ public class GreyNoiseCommunityIpLookupAdapter extends LookupDataAdapter {
     public static class Descriptor extends LookupDataAdapter.Descriptor<GreyNoiseCommunityIpLookupAdapter.Config> {
 
         public Descriptor() {
-            super(ADAPTER_NAME, GreyNoiseCommunityIpLookupAdapter.Config.class);
+            super(ADAPTER_NAME + DEPRECATED, GreyNoiseCommunityIpLookupAdapter.Config.class);
         }
 
         @Override

--- a/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapter.java
+++ b/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapter.java
@@ -53,7 +53,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
- * The GreyNoiseCommunityIpLookupAdapter class is deprecated as of https://github.com/Graylog2/graylog-plugin-integrations/pull/1340.
+ * The GreyNoiseCommunityIpLookupAdapter class is deprecated as of <a href="https://github.com/Graylog2/graylog-plugin-integrations/pull/1340</a>.
  *
  * A {@link LookupDataAdapter} that uses the <a href="https://docs.greynoise.io/reference/get_v3-community-ip">GreyNoise Community API</a>
  * to perform IP lookups.
@@ -97,7 +97,7 @@ public class GreyNoiseCommunityIpLookupAdapter extends LookupDataAdapter {
 
     @Override
     protected void doStart() throws Exception {
-        throw new Exception("GreyNoise Community IP Lookup is no longer supported.");
+        throw new Exception("GreyNoise Community IP Lookup Data Adapter is no longer supported.");
     }
 
     @Override
@@ -122,9 +122,10 @@ public class GreyNoiseCommunityIpLookupAdapter extends LookupDataAdapter {
 
     @Override
     protected LookupResult doGet(Object ipAddress) {
-        return LookupResult.withError("GreyNoise Community IP Lookup Data Adapter is no deprecated and lookups can no longer be performed.");
+        return LookupResult.withError("GreyNoise Community IP Lookup Data Adapter is deprecated and lookups can no longer be performed.");
     }
 
+    // This is the old doGet() method, left in case this functionality needs to be restored in the future.
     protected LookupResult doDoGet(Object ipAddress) {
 
 

--- a/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapter.java
+++ b/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapter.java
@@ -53,6 +53,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
+ * The GreyNoiseCommunityIpLookupAdapter class is deprecated as of https://github.com/Graylog2/graylog-plugin-integrations/pull/1340.
+ *
  * A {@link LookupDataAdapter} that uses the <a href="https://docs.greynoise.io/reference/get_v3-community-ip">GreyNoise Community API</a>
  * to perform IP lookups.
  *
@@ -93,8 +95,8 @@ public class GreyNoiseCommunityIpLookupAdapter extends LookupDataAdapter {
     }
 
     @Override
-    protected void doStart(){
-        //Not needed
+    protected void doStart() throws Exception {
+        throw new Exception("GreyNoise Community IP Lookup is no longer supported.");
     }
 
     @Override
@@ -122,25 +124,24 @@ public class GreyNoiseCommunityIpLookupAdapter extends LookupDataAdapter {
         return LookupResult.withError("GreyNoise Community IP Lookup Data Adapter is no deprecated and lookups can no longer be performed.");
     }
 
-//    @Override
-//    protected LookupResult doGet(Object ipAddress) {
-//
-//
-//        Optional<Request> request = createRequest(ipAddress);
-//        if (!request.isPresent()) {
-//            return LookupResult.withError();
-//        }
-//
-//        LookupResult result;
-//        try (Response response = okHttpClient.newCall(request.get()).execute()) {
-//            result = parseResponse(response);
-//
-//        } catch (IOException e) {
-//            LOG.error("an error occurred while retrieving GreyNoise IP data. {}", e.getMessage(), e);
-//            result = LookupResult.withError();
-//        }
-//        return result;
-//    }
+    protected LookupResult doDoGet(Object ipAddress) {
+
+
+        Optional<Request> request = createRequest(ipAddress);
+        if (!request.isPresent()) {
+            return LookupResult.withError();
+        }
+
+        LookupResult result;
+        try (Response response = okHttpClient.newCall(request.get()).execute()) {
+            result = parseResponse(response);
+
+        } catch (IOException e) {
+            LOG.error("an error occurred while retrieving GreyNoise IP data. {}", e.getMessage(), e);
+            result = LookupResult.withError();
+        }
+        return result;
+    }
 
     @VisibleForTesting
     Optional<Request> createRequest(Object ipAddress) {

--- a/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapter.java
+++ b/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapter.java
@@ -65,7 +65,7 @@ import java.util.stream.Collectors;
 @Deprecated
 public class GreyNoiseCommunityIpLookupAdapter extends LookupDataAdapter {
 
-    public static final String ADAPTER_NAME = "GreyNoise Community IP Lookup";
+    public static final String ADAPTER_NAME = "GreyNoise Community IP Lookup [Deprecated]";
 
     protected static final String GREYNOISE_COMMUNITY_ENDPOINT = "https://api.greynoise.io/v3/community";
 

--- a/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapter.java
+++ b/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapter.java
@@ -32,6 +32,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.apache.commons.validator.routines.InetAddressValidator;
+import org.graylog.plugins.threatintel.tools.AdapterDisabledException;
 import org.graylog2.plugin.lookup.LookupCachePurge;
 import org.graylog2.plugin.lookup.LookupDataAdapter;
 import org.graylog2.plugin.lookup.LookupDataAdapterConfiguration;
@@ -66,7 +67,6 @@ import java.util.stream.Collectors;
 public class GreyNoiseCommunityIpLookupAdapter extends LookupDataAdapter {
 
     public static final String ADAPTER_NAME = "GreyNoise Community IP Lookup";
-    public static final String DEPRECATED = " [Deprecated]";
 
     protected static final String GREYNOISE_COMMUNITY_ENDPOINT = "https://api.greynoise.io/v3/community";
 
@@ -97,7 +97,7 @@ public class GreyNoiseCommunityIpLookupAdapter extends LookupDataAdapter {
 
     @Override
     protected void doStart() throws Exception {
-        throw new Exception("GreyNoise Community IP Lookup Data Adapter is no longer supported.");
+        throw new AdapterDisabledException("The GreyNoise Community IP Lookup Data Adapter is no longer supported. This Data Adapter should be deleted.");
     }
 
     @Override
@@ -270,7 +270,7 @@ public class GreyNoiseCommunityIpLookupAdapter extends LookupDataAdapter {
     public static class Descriptor extends LookupDataAdapter.Descriptor<GreyNoiseCommunityIpLookupAdapter.Config> {
 
         public Descriptor() {
-            super(ADAPTER_NAME + DEPRECATED, GreyNoiseCommunityIpLookupAdapter.Config.class);
+            super(ADAPTER_NAME, GreyNoiseCommunityIpLookupAdapter.Config.class);
         }
 
         @Override

--- a/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapter.java
+++ b/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseCommunityIpLookupAdapter.java
@@ -60,6 +60,7 @@ import java.util.stream.Collectors;
  * The API response is a subset of the IP context returned by the full IP Lookup API.
  * </p>
  */
+@Deprecated
 public class GreyNoiseCommunityIpLookupAdapter extends LookupDataAdapter {
 
     public static final String ADAPTER_NAME = "GreyNoise Community IP Lookup";

--- a/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseQuickIPDataAdapter.java
+++ b/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseQuickIPDataAdapter.java
@@ -33,6 +33,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.apache.commons.validator.routines.InetAddressValidator;
+import org.graylog.plugins.threatintel.tools.AdapterDisabledException;
 import org.graylog2.plugin.lookup.LookupCachePurge;
 import org.graylog2.plugin.lookup.LookupDataAdapter;
 import org.graylog2.plugin.lookup.LookupDataAdapterConfiguration;
@@ -79,7 +80,7 @@ public class GreyNoiseQuickIPDataAdapter extends LookupDataAdapter {
     public void doStart() throws Exception {
         if (!isValidSubscription(encryptedValueService.decrypt(config.apiToken()))) {
             VALID_GREYNOISE_LICENSE.set(false);
-            throw new Exception("Cannot start Data Adapter without a GreyNoise Enterprise subscription. Check API key and restart Data Adapter.");
+            throw new AdapterDisabledException("Cannot start Data Adapter without a GreyNoise Enterprise subscription. Check API key and restart Data Adapter.");
         } else {
             VALID_GREYNOISE_LICENSE.set(true);
         }

--- a/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseQuickIPDataAdapter.java
+++ b/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseQuickIPDataAdapter.java
@@ -71,15 +71,13 @@ public class GreyNoiseQuickIPDataAdapter extends LookupDataAdapter {
         this.config = (Config) config;
         this.encryptedValueService = encryptedValueService;
         this.okHttpClient = okHttpClient;
-
-        if (!isEnterpriseSubscription()) {
-            throw new RuntimeException("A GreyNoise Enterprise subscription is required.");
-        }
     }
 
     @Override
     public void doStart() throws Exception {
-
+        if (!isEnterpriseSubscription()) {
+            throw new Exception("Cannot start GreyNoise Data Adapter. A GreyNoise Enterprise subscription is required.");
+        }
     }
 
     @Override
@@ -159,6 +157,7 @@ public class GreyNoiseQuickIPDataAdapter extends LookupDataAdapter {
     public void set(Object key, Object value) {
     }
 
+    // Check if provided API token has a valid GreyNoise Enterprise subscription.
     private boolean isEnterpriseSubscription() {
         Request request = new Request.Builder()
                 .url(GREYNOISE_PING_ENDPOINT)
@@ -167,6 +166,7 @@ public class GreyNoiseQuickIPDataAdapter extends LookupDataAdapter {
                 .addHeader("key", encryptedValueService.decrypt(config.apiToken()))
                 .addHeader("User-Agent", "Graylog")
                 .build();
+
         try (Response response = okHttpClient.newCall(request).execute()) {
             JSONObject json = new JSONObject(response.body().string());
             return response.code() == 200 && json.hasField("offering") && !json.getFieldAsString("offering").equals("community");

--- a/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseQuickIPDataAdapter.java
+++ b/src/main/java/org/graylog/integrations/dataadapters/GreyNoiseQuickIPDataAdapter.java
@@ -103,7 +103,8 @@ public class GreyNoiseQuickIPDataAdapter extends LookupDataAdapter {
     @Override
     protected LookupResult doGet(Object keyObject) {
         if (!VALID_GREYNOISE_LICENSE.get()) {
-            return LookupResult.withError("Cannot perform lookup without a GreyNoise Enterprise subscription. Check API key and restart Data Adapter.");
+            return LookupResult.withError("Cannot perform lookup without a GreyNoise Enterprise subscription."
+                    + " Check API key and restart Data Adapter.");
         }
 
         String ip = keyObject.toString();

--- a/src/main/java/org/graylog/integrations/migrations/V20230522201200_NotificationForDeprecatedGreyNoiseCommunityDataAdapters.java
+++ b/src/main/java/org/graylog/integrations/migrations/V20230522201200_NotificationForDeprecatedGreyNoiseCommunityDataAdapters.java
@@ -48,7 +48,7 @@ public class V20230522201200_NotificationForDeprecatedGreyNoiseCommunityDataAdap
             final Notification systemNotification = notificationService.buildNow()
                     .addType(Notification.Type.GENERIC)
                     .addSeverity(Notification.Severity.URGENT)
-                    .addDetail("title", StringUtils.f("Disabled Data Adapters [%s]", greyNoiseCommunityAdapters.toString()))
+                    .addDetail("title", StringUtils.f("Disabled Data Adapters %s", greyNoiseCommunityAdapters.toString()))
                     .addDetail("description", "GreyNoise Community IP Lookup Data Adapters are no longer supported as of Graylog 5.2."
                             + " GreyNoise Community Data Adapter lookups will no longer return results and any should be deleted.");
 

--- a/src/main/java/org/graylog/integrations/migrations/V20230522201200_NotificationForDeprecatedGreyNoiseCommunityDataAdapters.java
+++ b/src/main/java/org/graylog/integrations/migrations/V20230522201200_NotificationForDeprecatedGreyNoiseCommunityDataAdapters.java
@@ -66,7 +66,7 @@ public class V20230522201200_NotificationForDeprecatedGreyNoiseCommunityDataAdap
                     .addSeverity(Notification.Severity.URGENT)
                     .addDetail("title", StringUtils.f("Disabled Data Adapters %s", greyNoiseCommunityAdapters.toString()))
                     .addDetail("description", "GreyNoise Community IP Lookup Data Adapters are no longer supported as of Graylog 5.2."
-                            + " GreyNoise Community Data Adapter lookups will no longer return results and any should be deleted.");
+                            + " GreyNoise Community Data Adapters will no longer return results and should be deleted.");
 
             notificationService.publishIfFirst(systemNotification);
         }

--- a/src/main/java/org/graylog/integrations/migrations/V20230522201200_NotificationForDeprecatedGreyNoiseCommunityDataAdapters.java
+++ b/src/main/java/org/graylog/integrations/migrations/V20230522201200_NotificationForDeprecatedGreyNoiseCommunityDataAdapters.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2020 Graylog, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the Server Side Public License, version 1,
+ * as published by MongoDB, Inc.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * Server Side Public License for more details.
+ *
+ * You should have received a copy of the Server Side Public License
+ * along with this program. If not, see
+ * <http://www.mongodb.com/licensing/server-side-public-license>.
+ */
 package org.graylog.integrations.migrations;
 
 import org.graylog.integrations.dataadapters.GreyNoiseCommunityIpLookupAdapter;

--- a/src/main/java/org/graylog/integrations/migrations/V20230522201200_RemoveGreyNoiseCommunityDataAdapters.java
+++ b/src/main/java/org/graylog/integrations/migrations/V20230522201200_RemoveGreyNoiseCommunityDataAdapters.java
@@ -1,0 +1,72 @@
+package org.graylog.integrations.migrations;
+
+import org.graylog.integrations.dataadapters.GreyNoiseCommunityIpLookupAdapter;
+import org.graylog2.lookup.db.DBDataAdapterService;
+import org.graylog2.lookup.dto.DataAdapterDto;
+import org.graylog2.migrations.Migration;
+import org.graylog2.notifications.Notification;
+import org.graylog2.notifications.NotificationService;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.system.NodeId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public class V20230522201200_RemoveGreyNoiseCommunityDataAdapters extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(V20230522201200_RemoveGreyNoiseCommunityDataAdapters.class);
+
+    private final ClusterConfigService clusterConfigService;
+    private final DBDataAdapterService dataAdapterService;
+    private final NotificationService notificationService;
+    private final NodeId nodeId;
+
+    @Inject
+    public V20230522201200_RemoveGreyNoiseCommunityDataAdapters(ClusterConfigService clusterConfigService,
+                                                                DBDataAdapterService dataAdapterService,
+                                                                NotificationService notificationService,
+                                                                NodeId nodeId) {
+        this.clusterConfigService = clusterConfigService;
+        this.dataAdapterService = dataAdapterService;
+        this.notificationService = notificationService;
+        this.nodeId = nodeId;
+    }
+
+    /**
+     * This migration removes all GreyNoise Community IP Lookup Data Adapters.
+     */
+    @Override
+    public void upgrade() {
+        if (clusterConfigService.get(V20230522201200_RemoveGreyNoiseCommunityDataAdapters.MigrationCompleted.class) != null) {
+            LOG.debug("Migration already completed!");
+            return;
+        }
+
+        List<DataAdapterDto> greyNoiseCommunityAdapters = dataAdapterService.findAll().stream()
+                .filter(da -> da.config() instanceof GreyNoiseCommunityIpLookupAdapter).toList();
+
+        greyNoiseCommunityAdapters.forEach(adapter -> {
+            dataAdapterService.deleteAndPostEvent(adapter.id());
+
+            final Notification systemNotification = notificationService.buildNow()
+                    .addNode(nodeId.getNodeId())
+                    .addType(Notification.Type.GENERIC)
+                    .addSeverity(Notification.Severity.URGENT)
+                    .addDetail("title", "Removed GreyNoise Community IP Lookup Data Adapter")
+                    .addDetail("description", "GreyNoise Community IP Lookup Data Adapters are no longer supported.");
+
+            notificationService.publishIfFirst(systemNotification);
+        });
+
+        clusterConfigService.write(new V20230522201200_RemoveGreyNoiseCommunityDataAdapters.MigrationCompleted());
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2023-05-22T20:12:00Z");
+    }
+
+    public record MigrationCompleted() {}
+}

--- a/src/web/dataadapters/GreyNoiseAdapterSummary.jsx
+++ b/src/web/dataadapters/GreyNoiseAdapterSummary.jsx
@@ -18,6 +18,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { Alert } from 'components/bootstrap';
+
 class GreyNoiseAdapterSummary extends React.Component {
   static propTypes = {
     dataAdapter: PropTypes.shape({
@@ -31,13 +33,17 @@ class GreyNoiseAdapterSummary extends React.Component {
   };
 
   render() {
-    const { config } = this.props.dataAdapter;
-
     return (
-      <dl>
-        <dt>API Token</dt>
-        <dd>******</dd>
-      </dl>
+        <div>
+          <dl>
+            <dt>API Token</dt>
+            <dd>******</dd>
+          </dl>
+          <Alert style={{marginBottom: 10}} bsStyle="warning">
+            <h4 style={{marginBottom: 10}}>Deprecation Warning</h4>
+            <p>The GreyNoise Community IP Lookup Data Adapter is no longer supported. This Data Adapter should not be used.</p>
+          </Alert>
+        </div>
     );
   }
 }

--- a/src/web/dataadapters/GreyNoiseAdapterSummary.jsx
+++ b/src/web/dataadapters/GreyNoiseAdapterSummary.jsx
@@ -39,7 +39,7 @@ class GreyNoiseAdapterSummary extends React.Component {
             <dt>API Token</dt>
             <dd>******</dd>
           </dl>
-          <Alert style={{marginBottom: 10}} bsStyle="warning">
+          <Alert style={{marginBottom: 10}} bsStyle="danger">
             <h4 style={{marginBottom: 10}}>Deprecation Warning</h4>
             <p>The GreyNoise Community IP Lookup Data Adapter is no longer supported. This Data Adapter should not be used.</p>
           </Alert>

--- a/src/web/dataadapters/GreyNoiseCommunityIpLookupAdapterDocumentation.jsx
+++ b/src/web/dataadapters/GreyNoiseCommunityIpLookupAdapterDocumentation.jsx
@@ -17,17 +17,16 @@
 /* eslint-disable react/no-unescaped-entities, no-template-curly-in-string */
 import React from 'react';
 
-import { ExternalLink } from 'components/common';
+import { Alert } from 'components/bootstrap';
 
 class GreyNoiseCommunityIpLookupAdapterDocumentation extends React.Component {
   render() {
-    const style = { marginBottom: 10 };
     return (
       <div>
-        <p style={style}>
-          The Community Greynoise IP lookup data adapter uses the <ExternalLink href="https://docs.greynoise.io/reference/get_v3-community-ip">Greynoise Community API</ExternalLink>.&nbsp;
-          The data returned is a subset of the full IP context data returned by the full IP Lookup API.
-        </p>
+          <Alert style={{ marginBottom: 10 }} bsStyle="warning">
+              <h4 style={{ marginBottom: 10 }}>Deprecation Warning</h4>
+              <p>The GreyNoise Community IP Lookup Data Adapter is no longer supported. This Data Adapter should not be used.</p>
+          </Alert>
       </div>
     )
     ;

--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -87,7 +87,7 @@ const manifest = new PluginManifest(packageJson, {
     },
     {
       type: 'GreyNoise Community IP Lookup',
-      displayName: 'GreyNoise Community IP Lookup',
+      displayName: '[Deprecated] GreyNoise Community IP Lookup',
       formComponent: GreyNoiseAdapterFieldSet,
       summaryComponent: GreyNoiseAdapterSummary,
       documentationComponent: GreyNoiseCommunityIpLookupAdapterDocumentation,


### PR DESCRIPTION
Removes some functionality for the various Data Adapters to limit Graylog's usage of the GreyNoise API. See https://github.com/Graylog2/graylog-plugin-enterprise/issues/5157 for more details.

- Deprecates GreyNoise Community IP Lookup Data Adapter
    - Disallows creation of new GreyNoise Community Data Adapter
    - Removes ability to start or perform lookups for existing Adapters
    - Adds migration that creates a system notification to warn users with existing Adapters of the above
- Removes ability to start or perform lookups for GreyNoise Quick IP Adapters with API tokens that are only associated with a GreyNoise community subscription

In sister PR https://github.com/Graylog2/graylog-plugin-enterprise-integrations/pull/1059:
- Removes ability to start or perform lookups for GreyNoise Full IP Lookup [Enterprise] Data Adapters with API tokens that are only associated with a GreyNoise community subscription

## Notes for Reviewers
Note: To test this you need a GreyNoise API token. You can get one by creating a free GreyNoise account and following the instructions here: https://docs.greynoise.io/docs

The initial account will be for a Community plan and can be used to test the community functionality. 
You can then also start a free 14 day Enterprise trial to test the non-community plan functionality by selecting here: https://viz.greynoise.io/account/plan

### Testing Notes
There are 3 Data Adapter types that were updated in this PR. Testing steps for each are below:

**GreyNoise Community IP Lookup**
1. Create some Data Adapters without this PR, then apply this PR
2. Check that migration has run successfully as evidenced by a system notification
3. Check that the Data Adapters don't start (should see logs and warning in the UI)
4. Check that lookups return an error result

**GreyNoise Full IP Lookup [Enterprise]**
1. Create a Data adapter with using community API token (with changes in https://github.com/Graylog2/graylog-plugin-enterprise-integrations/pull/1059) 
2. Check that the Data Adapters don't start (should see logs and warning in the UI)
3. Check that lookups return an error result

**GreyNoise Quick IP Lookup**
1. Create a Data adapter with using community API token and this PR applied 
2. Check that the Data Adapters don't start (should see logs and warning in the UI)
3. Check that lookups return an error result

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

