### PR TITLE
Backport 5.1: Add summary to teams adaptive card

### DIFF
--- a/changelog/unreleased/issue-1341.toml
+++ b/changelog/unreleased/issue-1341.toml
@@ -1,0 +1,5 @@
+type = "added"
+message = "Added event definition title as a summary to Microsoft Teams notifications."
+
+issues = ["1341"]
+pulls = ["1342"]

--- a/changelog/unreleased/issue-1341.toml
+++ b/changelog/unreleased/issue-1341.toml
@@ -2,4 +2,4 @@ type = "added"
 message = "Added event definition title as a summary to Microsoft Teams notifications."
 
 issues = ["1341"]
-pulls = ["1342"]
+pulls = ["1343"]

--- a/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotification.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsEventNotification.java
@@ -114,6 +114,7 @@ public class TeamsEventNotification implements EventNotification {
         String description = buildMessageDescription(ctx);
         String customMessage = null;
         String template = config.customMessage();
+        String summary = ctx.eventDefinition().map(EventDefinitionDto::title).orElse("Graylog Event");
         if (!isNullOrEmpty(template)) {
             customMessage = buildCustomMessage(ctx, config, template);
         }
@@ -127,6 +128,7 @@ public class TeamsEventNotification implements EventNotification {
         return TeamsMessage.builder()
                 .color(config.color())
                 .text(messageTitle)
+                .summary(summary)
                 .sections(Collections.singleton(section))
                 .build();
     }

--- a/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsMessage.java
+++ b/src/main/java/org/graylog/integrations/notifications/types/microsoftteams/TeamsMessage.java
@@ -38,6 +38,7 @@ public abstract class TeamsMessage {
     static final String FIELD_SECTIONS = "sections";
     static final String FIELD_ACTIVITY_SUBTITLE = "activitySubtitle";
     static final String FIELD_ACTIVITY_IMAGE = "activityImage";
+    static final String FIELD_SUMMARY = "summary";
 
     @JsonProperty(FIELD_TYPE)
     public abstract String type();
@@ -50,6 +51,9 @@ public abstract class TeamsMessage {
 
     @JsonProperty(FIELD_TEXT)
     public abstract String text();
+
+    @JsonProperty(FIELD_SUMMARY)
+    public abstract String summary();
 
     @JsonProperty(FIELD_SECTIONS)
     public abstract Set<Sections> sections();
@@ -73,6 +77,9 @@ public abstract class TeamsMessage {
 
         @JsonProperty(FIELD_TEXT)
         public abstract Builder text(String text);
+
+        @JsonProperty(FIELD_SUMMARY)
+        public abstract Builder summary(String summary);
 
         @JsonProperty(FIELD_SECTIONS)
         public abstract Builder sections(Set<Sections> sections);


### PR DESCRIPTION
## Notes for Reviewers

Backport #1343 to 5.1

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

