### PR TITLE
Fix changelog PR typo in most recent changelog

### DIFF
--- a/changelog/unreleased/issue-1341.toml
+++ b/changelog/unreleased/issue-1341.toml
@@ -2,4 +2,4 @@ type = "added"
 message = "Added event definition title as a summary to Microsoft Teams notifications."
 
 issues = ["1341"]
-pulls = ["1342"]
+pulls = ["1343"]


### PR DESCRIPTION
## Notes for Reviewers
Realized while making backport PRs that I messed up the PR number in the changelog

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

