### PR TITLE
Changing the GitHub templates to ask for OpenSearch version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,6 +19,6 @@ assignees: ''
 ## Environment
 
 - Graylog Version:
-- Elasticsearch Version:
+- OpenSearch Version:
 - MongoDB Version:
 - Browser Version:


### PR DESCRIPTION
Changing the bug/feature templates to ask for the OpenSearch version instead of Elasticsearch.

/nocl
